### PR TITLE
RM-6801: Add DiagnosticScreenshotBuilder

### DIFF
--- a/Remotion/Web/Development.WebTesting.IntegrationTests.Infrastructure/DiagnosticScreenshotBuilder.cs
+++ b/Remotion/Web/Development.WebTesting.IntegrationTests.Infrastructure/DiagnosticScreenshotBuilder.cs
@@ -1,0 +1,72 @@
+﻿// This file is part of the re-motion Core Framework (www.re-motion.org)
+// Copyright (c) rubicon IT GmbH, www.rubicon.eu
+// 
+// The re-motion Core Framework is free software; you can redistribute it 
+// and/or modify it under the terms of the GNU Lesser General Public License 
+// as published by the Free Software Foundation; either version 2.1 of the 
+// License, or (at your option) any later version.
+// 
+// re-motion is distributed in the hope that it will be useful, 
+// but WITHOUT ANY WARRANTY; without even the implied warranty of 
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with re-motion; if not, see http://www.gnu.org/licenses.
+// 
+using System;
+using System.Drawing.Imaging;
+using System.IO;
+using JetBrains.Annotations;
+using Remotion.Utilities;
+using Remotion.Web.Development.WebTesting.BrowserSession;
+using Remotion.Web.Development.WebTesting.ScreenshotCreation;
+
+namespace Remotion.Web.Development.WebTesting.IntegrationTests.Infrastructure
+{
+  /// <summary>
+  /// Provides means of annotating or cropping a <see cref="Screenshot"/>, and saving the annotation independently.
+  /// </summary>
+  public class DiagnosticScreenshotBuilder : ScreenshotBuilder
+  {
+    [NotNull]
+    public static DiagnosticScreenshotBuilder CreateDesktopScreenshot ([NotNull] IBrowserContentLocator contentLocator)
+    {
+      ArgumentUtility.CheckNotNull ("contentLocator", contentLocator);
+
+      return new DiagnosticScreenshotBuilder (Screenshot.TakeDesktopScreenshot(), contentLocator);
+    }
+
+    [NotNull]
+    public static DiagnosticScreenshotBuilder CreateBrowserScreenshot ([NotNull] IBrowserContentLocator contentLocator, [NotNull] IBrowserSession browserSession)
+    {
+      ArgumentUtility.CheckNotNull ("contentLocator", contentLocator);
+      ArgumentUtility.CheckNotNull ("browserSession", browserSession);
+
+      return new DiagnosticScreenshotBuilder (
+          Screenshot.TakeBrowserScreenshot (browserSession, contentLocator),
+          contentLocator);
+    }
+
+    private DiagnosticScreenshotBuilder ([NotNull] Screenshot screenshot, [NotNull] IBrowserContentLocator locator)
+        : base (screenshot, locator)
+    {
+    }
+
+    public void SaveAnnotation ([NotNull] string path, bool overwriteFileIfExists = false)
+    {
+      ArgumentUtility.CheckNotNullOrEmpty ("path", path);
+
+      if (!overwriteFileIfExists && File.Exists (path))
+        throw new InvalidOperationException (string.Format ("A screenshot with the file name '{0}' does already exist.", path));
+
+      var directory = Path.GetDirectoryName (path);
+      Directory.CreateDirectory (directory);
+
+      using (var annotationImage = AnnotationLayer.CloneImage())
+      {
+        annotationImage.Save (path, ImageFormat.Png);
+      }
+    }
+  }
+}

--- a/Remotion/Web/Development.WebTesting.IntegrationTests.Infrastructure/Web.Development.WebTesting.IntegrationTests.Infrastructure.csproj
+++ b/Remotion/Web/Development.WebTesting.IntegrationTests.Infrastructure/Web.Development.WebTesting.IntegrationTests.Infrastructure.csproj
@@ -73,6 +73,7 @@
     <Compile Include="CustomUserDirectory.cs" />
     <Compile Include="CustomWebTestConfigurationFactory.cs" />
     <Compile Include="Delegates.cs" />
+    <Compile Include="DiagnosticScreenshotBuilder.cs" />
     <Compile Include="GenericTestPageParameterDictionaryExtensions.cs" />
     <Compile Include="GenericTestPageParameterDto.cs" />
     <Compile Include="GenericTestPageParameter.cs" />

--- a/Remotion/Web/Development.WebTesting/ScreenshotCreation/ScreenshotBuilder.cs
+++ b/Remotion/Web/Development.WebTesting/ScreenshotCreation/ScreenshotBuilder.cs
@@ -16,144 +16,68 @@
 // 
 using System;
 using System.Drawing;
-using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.IO;
 using JetBrains.Annotations;
 using Remotion.Utilities;
-using Remotion.Web.Development.WebTesting.ScreenshotCreation.Transformations;
 
 namespace Remotion.Web.Development.WebTesting.ScreenshotCreation
 {
   /// <summary>
   /// Provides means of annotating or cropping a <see cref="Screenshot"/>.
   /// </summary>
-  public class ScreenshotBuilder
+  public class ScreenshotBuilder : IDisposable
   {
-    private class TransformationHelper<T> : IDisposable
-    {
-      private readonly ScreenshotTransformationContext<T> _context;
-      private readonly IScreenshotTransformation<T> _transformation;
+    /// <summary>
+    /// Returns <see langword="true" /> if the mouse cursor should be drawn onto the screenshot, otherwise <see langword="false" />.
+    /// </summary>
+    public bool DrawMouseCursor { get; set; }
 
-      public TransformationHelper (
-          ScreenshotManipulation manipulation,
-          Graphics graphics,
-          IScreenshotElementResolver<T> resolver,
-          T target,
-          CoordinateSystem coordinateSystem,
-          IScreenshotTransformation<T> transformation,
-          IBrowserContentLocator locator)
-      {
-        var resolvedElement = Resolve (resolver, target, locator, coordinateSystem);
-        var context = new ScreenshotTransformationContext<T> (manipulation, graphics, resolver, target, resolvedElement);
+    /// <summary>
+    /// Returns the minimum <see cref="ElementVisibility"/> a screenshot element must have in order to be annotated / cropped.
+    /// </summary>
+    public ElementVisibility MinimumVisibility { get; set; }
 
-        context = transformation.BeginApply (context);
+    /// <summary>
+    /// The <see cref="ScreenshotCreation.Screenshot"/> behind the <see cref="ScreenshotBuilder"/> instance.
+    /// </summary>
+    [NotNull]
+    public Screenshot Screenshot { get; }
 
-        var parentBounds = context.ResolvedElement.ParentBounds;
-        if (parentBounds.HasValue)
-        {
-          _context =
-              context.CloneWith (
-                  resolvedElement:
-                      resolvedElement.CloneWith (elementBounds: Rectangle.Intersect (parentBounds.Value, context.ResolvedElement.ElementBounds)));
-        }
-        else
-        {
-          _context = context;
-        }
+    /// <summary>
+    /// The base layer of the image, containing the screenshot.
+    /// </summary>
+    [NotNull]
+    protected ScreenshotLayer BaseLayer { get; }
 
-        _transformation = transformation;
-      }
-
-      public ScreenshotTransformationContext<T> Context
-      {
-        get { return _context; }
-      }
-
-      public void Dispose ()
-      {
-        _transformation.EndApply (_context);
-      }
-
-      private ResolvedScreenshotElement Resolve (
-          IScreenshotElementResolver<T> resolver,
-          T target,
-          IBrowserContentLocator locator,
-          CoordinateSystem coordinateSystem)
-      {
-        switch (coordinateSystem)
-        {
-          case CoordinateSystem.Browser:
-            return resolver.ResolveBrowserCoordinates (target);
-          case CoordinateSystem.Desktop:
-            return resolver.ResolveDesktopCoordinates (target, locator);
-          default:
-            throw new ArgumentOutOfRangeException ("coordinateSystem", coordinateSystem, null);
-        }
-      }
-    }
-
-    private readonly IBrowserContentLocator _locator;
-
-    private Graphics _graphics;
-    private Rectangle _imageBounds;
-    private Size _normalizationVector;
-    private Screenshot _screenshot;
-
-    private bool _drawMouseCursor;
-    private ElementVisibility _minimumVisibility;
+    /// <summary>
+    /// The annotation layer of the image, containing the annotations.
+    /// </summary>
+    [NotNull]
+    protected ScreenshotLayer AnnotationLayer { get; }
 
     public ScreenshotBuilder ([NotNull] Screenshot screenshot, [NotNull] IBrowserContentLocator locator)
     {
       ArgumentUtility.CheckNotNull ("screenshot", screenshot);
       ArgumentUtility.CheckNotNull ("locator", locator);
 
-      _screenshot = screenshot;
-      _locator = locator;
+      Screenshot = screenshot;
+      DrawMouseCursor = false;
+      MinimumVisibility = ElementVisibility.FullyVisible;
 
-      _graphics = Graphics.FromImage (_screenshot.Image);
-
-      _drawMouseCursor = false;
-      _minimumVisibility = ElementVisibility.FullyVisible;
-
-      PrepareScreenshot();
-    }
-
-    /// <summary>
-    /// Returns <see langword="true" /> if the mouse cursor should be drawn onto the screenshot, otherwise <see langword="false" />.
-    /// </summary>
-    public bool DrawMouseCursor
-    {
-      get { return _drawMouseCursor; }
-      set { _drawMouseCursor = value; }
-    }
-
-    /// <summary>
-    /// Returns the minimum <see cref="ElementVisibility"/> a screenshot element must have in order to be annotated / cropped.
-    /// </summary>
-    public ElementVisibility MinimumVisibility
-    {
-      get { return _minimumVisibility; }
-      set { _minimumVisibility = value; }
-    }
-
-    /// <summary>
-    /// The <see cref="ScreenshotCreation.Screenshot"/> behind the <see cref="ScreenshotBuilder"/> instance.
-    /// </summary>
-    public Screenshot Screenshot
-    {
-      get { return _screenshot; }
+      BaseLayer = ScreenshotLayer.Create (screenshot, locator);
+      AnnotationLayer = ScreenshotLayer.CreateTransparent (screenshot, locator);
     }
 
     /// <summary>
     /// Annotates the whole image with <paramref name="annotation"/>.
     /// </summary>
+    [NotNull]
     public ScreenshotBuilder Annotate ([NotNull] IScreenshotAnnotation annotation)
     {
       ArgumentUtility.CheckNotNull ("annotation", annotation);
 
-      var resolvedElement = new ResolvedScreenshotElement (_screenshot.CoordinateSystem, _imageBounds, ElementVisibility.FullyVisible, _imageBounds, _imageBounds);
-      annotation.Draw (_graphics, resolvedElement);
+      AnnotationLayer.Annotate (annotation);
 
       return this;
     }
@@ -161,6 +85,7 @@ namespace Remotion.Web.Development.WebTesting.ScreenshotCreation
     /// <summary>
     /// Annotates <paramref name="target"/> with <paramref name="annotation"/>.
     /// </summary>
+    [NotNull]
     public ScreenshotBuilder Annotate<T> (
         [NotNull] T target,
         [NotNull] IScreenshotElementResolver<T> resolver,
@@ -172,14 +97,7 @@ namespace Remotion.Web.Development.WebTesting.ScreenshotCreation
       ArgumentUtility.CheckNotNull ("resolver", resolver);
       ArgumentUtility.CheckNotNull ("annotation", annotation);
 
-      using (var helper = CreateTransformationHelper (ScreenshotManipulation.Annotate, resolver, target, transformation))
-      {
-        var context = helper.Context;
-
-        ValidateResolvedElement (context.ResolvedElement, minimumElementVisibility);
-
-        annotation.Draw (context.Graphics, context.ResolvedElement);
-      }
+      AnnotationLayer.Annotate (target, resolver, annotation, transformation, minimumElementVisibility);
 
       return this;
     }
@@ -187,6 +105,7 @@ namespace Remotion.Web.Development.WebTesting.ScreenshotCreation
     /// <summary>
     /// Crops the screenshot around <paramref name="target"/> using the specified <paramref name="cropping"/>.
     /// </summary>
+    [NotNull]
     public ScreenshotBuilder Crop<T> (
         [NotNull] T target,
         [NotNull] IScreenshotElementResolver<T> resolver,
@@ -198,20 +117,8 @@ namespace Remotion.Web.Development.WebTesting.ScreenshotCreation
       ArgumentUtility.CheckNotNull ("resolver", resolver);
       ArgumentUtility.CheckNotNull ("cropping", cropping);
 
-
-      using (var helper = CreateTransformationHelper (ScreenshotManipulation.Annotate, resolver, target, transformation))
-      {
-        var context = helper.Context;
-
-        ValidateResolvedElement (context.ResolvedElement, minimumElementVisibility);
-
-        var croppingRegion = cropping.ApplyOnElement (_imageBounds, context.ResolvedElement);
-
-        if (croppingRegion.IsEmpty)
-          throw new InvalidOperationException ("Cropping must result in an image which is not empty.");
-
-        CropRectangle (croppingRegion);
-      }
+      BaseLayer.Crop (target, resolver, cropping, transformation, minimumElementVisibility);
+      AnnotationLayer.Crop (target, resolver, cropping, transformation, minimumElementVisibility);
 
       return this;
     }
@@ -223,103 +130,31 @@ namespace Remotion.Web.Development.WebTesting.ScreenshotCreation
     {
       ArgumentUtility.CheckNotNullOrEmpty ("path", path);
 
-      if (_drawMouseCursor && _screenshot.CursorInformation.IsVisible)
-        _screenshot.CursorInformation.Draw (_graphics);
-
       if (!@override && File.Exists (path))
         throw new InvalidOperationException (string.Format ("A screenshot with the file name '{0}' does already exist.", path));
 
       var directory = Path.GetDirectoryName (path);
-      if (Directory.Exists (directory))
-        Directory.CreateDirectory (directory);
+      Directory.CreateDirectory (directory);
 
-      _graphics.Flush();
-      _screenshot.Image.Save (path, ImageFormat.Png);
-    }
-
-    private TransformationHelper<T> CreateTransformationHelper<T> (
-        ScreenshotManipulation manipulation,
-        IScreenshotElementResolver<T> resolver,
-        T target,
-        [CanBeNull] IScreenshotTransformation<T> transformation)
-    {
-      return new TransformationHelper<T> (
-          manipulation,
-          _graphics,
-          resolver,
-          target,
-          _screenshot.CoordinateSystem,
-          transformation ?? EmptyTransformation<T>.Instance,
-          _locator);
-    }
-
-    private void CropRectangle (Rectangle croppingRectangle)
-    {
-      var image = _screenshot.Image;
-
-      var newImage = new Bitmap (image, croppingRectangle.Size);
-      var newGraphics = Graphics.FromImage (newImage);
-
-      if (_graphics != null)
+      using (var annotationImage = AnnotationLayer.CloneImage())
+      using (var outputImage = BaseLayer.CloneImage())
+      using (var outputGraphics = Graphics.FromImage (outputImage))
       {
-        _graphics.Flush();
-        _graphics.Dispose();
-        _graphics = null;
+        outputGraphics.DrawImage (annotationImage, Point.Empty);
+
+        if (DrawMouseCursor && Screenshot.CursorInformation.IsVisible)
+          Screenshot.CursorInformation.Draw (outputGraphics);
+
+        outputImage.Save (path, ImageFormat.Png);
       }
-
-      var newImageBounds = new Rectangle (Point.Empty, croppingRectangle.Size);
-
-      var normalizedCroppingRectangle = new Rectangle (croppingRectangle.Location + _normalizationVector, croppingRectangle.Size);
-      newGraphics.FillRectangle (Brushes.Transparent, newImageBounds);
-      newGraphics.DrawImage (image, newImageBounds, normalizedCroppingRectangle, GraphicsUnit.Pixel);
-
-      var newScreenshot = new Screenshot (
-          newImage,
-          new Size (croppingRectangle.Location),
-          new[] { croppingRectangle },
-          _screenshot.CursorInformation,
-          _screenshot.CoordinateSystem);
-
-      _screenshot.Dispose();
-      _screenshot = newScreenshot;
-      _graphics = newGraphics;
-
-      PrepareScreenshot();
     }
 
-    private void PrepareScreenshot ()
+    /// <inheritdoc />
+    public void Dispose ()
     {
-      _normalizationVector = new Size (-_screenshot.DesktopOffset.Width, -_screenshot.DesktopOffset.Height);
-
-      var transformationMatrix = new Matrix();
-      transformationMatrix.Translate (_normalizationVector.Width, _normalizationVector.Height);
-      _graphics.Transform = transformationMatrix;
-
-      _imageBounds = new Rectangle (
-          _screenshot.DesktopOffset.Width,
-          _screenshot.DesktopOffset.Height,
-          _screenshot.Image.Width,
-          _screenshot.Image.Height);
-    }
-
-    private void ValidateResolvedElement (ResolvedScreenshotElement resolvedElement, ElementVisibility? minimumElementVisibility)
-    {
-      var visibility = minimumElementVisibility ?? _minimumVisibility;
-
-      if (resolvedElement.ElementVisibility < visibility)
-      {
-        throw new InvalidOperationException (
-            string.Format (
-                "The visibility of the resolved element is smaller than the specified minimum visibility. (visibility: {0}; required: {1})",
-                resolvedElement.ElementVisibility,
-                _minimumVisibility));
-      }
-
-      if (resolvedElement.ElementBounds.Width == 0 || resolvedElement.ElementBounds.Height == 0)
-        throw new InvalidOperationException ("The specified target is empty.");
-
-      if (!_screenshot.Contains (resolvedElement.ElementBounds))
-        throw new InvalidOperationException ("The specified target is not part of the screenshot.");
+      Screenshot.Dispose();
+      BaseLayer.Dispose();
+      AnnotationLayer.Dispose();
     }
   }
 }

--- a/Remotion/Web/Development.WebTesting/ScreenshotCreation/ScreenshotLayer.cs
+++ b/Remotion/Web/Development.WebTesting/ScreenshotCreation/ScreenshotLayer.cs
@@ -1,0 +1,246 @@
+﻿// This file is part of the re-motion Core Framework (www.re-motion.org)
+// Copyright (c) rubicon IT GmbH, www.rubicon.eu
+// 
+// The re-motion Core Framework is free software; you can redistribute it 
+// and/or modify it under the terms of the GNU Lesser General Public License 
+// as published by the Free Software Foundation; either version 2.1 of the 
+// License, or (at your option) any later version.
+// 
+// re-motion is distributed in the hope that it will be useful, 
+// but WITHOUT ANY WARRANTY; without even the implied warranty of 
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with re-motion; if not, see http://www.gnu.org/licenses.
+// 
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Linq;
+using JetBrains.Annotations;
+using Remotion.Utilities;
+using Remotion.Web.Development.WebTesting.ScreenshotCreation.Transformations;
+
+namespace Remotion.Web.Development.WebTesting.ScreenshotCreation
+{
+  /// <summary>
+  /// Represents a manipulable image layer for a <see cref="Screenshot"/>.
+  /// </summary>
+  public class ScreenshotLayer : IDisposable
+  {
+    /// <summary>
+    /// Creates a base layer for a given <see cref="Screenshot"/>.
+    /// </summary>
+    [NotNull]
+    public static ScreenshotLayer Create ([NotNull] Screenshot screenshot, [NotNull] IBrowserContentLocator locator)
+    {
+      ArgumentUtility.CheckNotNull ("screenshot", screenshot);
+      ArgumentUtility.CheckNotNull ("locator", locator);
+
+      return new ScreenshotLayer (screenshot, locator);
+    }
+
+    /// <summary>
+    /// Creates a transparent layer with the size of the given <see cref="Screenshot"/>.
+    /// </summary>
+    [NotNull]
+    public static ScreenshotLayer CreateTransparent ([NotNull] Screenshot screenshot, [NotNull] IBrowserContentLocator locator)
+    {
+      ArgumentUtility.CheckNotNull ("screenshot", screenshot);
+      ArgumentUtility.CheckNotNull ("locator", locator);
+
+      var bitmapOfScreenshotSize = new Bitmap (screenshot.Image.Width, screenshot.Image.Height);
+      bitmapOfScreenshotSize.MakeTransparent();
+
+      return new ScreenshotLayer (screenshot, locator, bitmapOfScreenshotSize);
+    }
+
+    private readonly IBrowserContentLocator _locator;
+
+    private Image _layerImage;
+    private Graphics _layerGraphics;
+    private Rectangle _imageBounds;
+    private Size _normalizationVector;
+
+    private Size _screenshotOffset;
+    private Rectangle[] _screenshotBounds;
+
+    private readonly CoordinateSystem _coordinateSystem;
+
+    private ScreenshotLayer (Screenshot screenshot, IBrowserContentLocator locator)
+        : this (screenshot, locator, (Image) screenshot.Image.Clone())
+    {
+    }
+
+    private ScreenshotLayer (Screenshot screenshot, IBrowserContentLocator locator, Image imageOverride)
+    {
+      _locator = locator;
+      _layerImage = imageOverride;
+      _layerGraphics = Graphics.FromImage (_layerImage);
+
+      _screenshotOffset = screenshot.DesktopOffset;
+      _screenshotBounds = screenshot.ScreenshotBounds;
+      _coordinateSystem = screenshot.CoordinateSystem;
+
+      PrepareScreenshotLayer();
+    }
+
+    /// <summary>
+    /// Annotates the whole layer with <paramref name="annotation"/>.
+    /// </summary>
+    public void Annotate ([NotNull] IScreenshotAnnotation annotation)
+    {
+      ArgumentUtility.CheckNotNull ("annotation", annotation);
+
+      var resolvedElement = new ResolvedScreenshotElement (_coordinateSystem, _imageBounds, ElementVisibility.FullyVisible, _imageBounds, _imageBounds);
+      annotation.Draw (_layerGraphics, resolvedElement);
+    }
+
+    /// <summary>
+    /// Annotates <paramref name="target"/> with <paramref name="annotation"/>.
+    /// </summary>
+    public void Annotate<T> (
+        [NotNull] T target,
+        [NotNull] IScreenshotElementResolver<T> resolver,
+        [NotNull] IScreenshotAnnotation annotation,
+        [CanBeNull] IScreenshotTransformation<T> transformation = null,
+        ElementVisibility? minimumElementVisibility = null)
+    {
+      ArgumentUtility.CheckNotNull ("target", target);
+      ArgumentUtility.CheckNotNull ("resolver", resolver);
+      ArgumentUtility.CheckNotNull ("annotation", annotation);
+
+      using (var helper = CreateTransformationHelper (ScreenshotManipulation.Annotate, resolver, target, transformation))
+      {
+        var context = helper.Context;
+
+        ValidateResolvedElement (context.ResolvedElement, minimumElementVisibility);
+
+        annotation.Draw (context.Graphics, context.ResolvedElement);
+      }
+    }
+
+    /// <summary>
+    /// Crops the <see cref="ScreenshotLayer"/> around <paramref name="target"/> using the specified <paramref name="cropping"/>.
+    /// </summary>
+    public void Crop<T> (
+        [NotNull] T target,
+        [NotNull] IScreenshotElementResolver<T> resolver,
+        [NotNull] IScreenshotCropping cropping,
+        [CanBeNull] IScreenshotTransformation<T> transformation = null,
+        ElementVisibility? minimumElementVisibility = null)
+    {
+      ArgumentUtility.CheckNotNull ("target", target);
+      ArgumentUtility.CheckNotNull ("resolver", resolver);
+      ArgumentUtility.CheckNotNull ("cropping", cropping);
+
+
+      using (var helper = CreateTransformationHelper (ScreenshotManipulation.Annotate, resolver, target, transformation))
+      {
+        var context = helper.Context;
+
+        ValidateResolvedElement (context.ResolvedElement, minimumElementVisibility);
+
+        var croppingRegion = cropping.ApplyOnElement (_imageBounds, context.ResolvedElement);
+
+        if (croppingRegion.IsEmpty)
+          throw new InvalidOperationException ("Cropping must result in an image which is not empty.");
+
+        CropRectangle (croppingRegion);
+      }
+    }
+
+    /// <summary>
+    /// Gets a copy of the image content of the layer.
+    /// </summary>
+    [NotNull]
+    public Image CloneImage ()
+    {
+      _layerGraphics.Flush();
+      return (Image) _layerImage.Clone();
+    }
+
+    /// <inheritdoc />
+    public void Dispose ()
+    {
+      _layerImage.Dispose();
+      _layerGraphics.Dispose();
+    }
+
+    private void PrepareScreenshotLayer ()
+    {
+      _normalizationVector = new Size (-_screenshotOffset.Width, -_screenshotOffset.Height);
+
+      var transformationMatrix = new Matrix();
+      transformationMatrix.Translate (_normalizationVector.Width, _normalizationVector.Height);
+      _layerGraphics.Transform = transformationMatrix;
+
+      _imageBounds = new Rectangle (
+          _screenshotOffset.Width,
+          _screenshotOffset.Height,
+          _layerImage.Width,
+          _layerImage.Height);
+    }
+
+    private void CropRectangle (Rectangle croppingRectangle)
+    {
+      _layerGraphics.Flush (FlushIntention.Sync);
+
+      var newImage = new Bitmap (croppingRectangle.Size.Width, croppingRectangle.Size.Height);
+      var newGraphics = Graphics.FromImage (newImage);
+      var newImageBounds = new Rectangle (Point.Empty, croppingRectangle.Size);
+
+      var normalizedCroppingRectangle = new Rectangle (croppingRectangle.Location + _normalizationVector, croppingRectangle.Size);
+      newGraphics.FillRectangle (Brushes.Transparent, newImageBounds);
+      newGraphics.DrawImage (_layerImage, newImageBounds, normalizedCroppingRectangle, GraphicsUnit.Pixel);
+
+      _screenshotOffset = new Size (croppingRectangle.Location);
+      _screenshotBounds = new[] { croppingRectangle };
+
+      _layerImage?.Dispose();
+      _layerImage = newImage;
+
+      _layerGraphics?.Dispose();
+      _layerGraphics = newGraphics;
+
+      PrepareScreenshotLayer();
+    }
+
+    private void ValidateResolvedElement (ResolvedScreenshotElement resolvedElement, ElementVisibility? minimumElementVisibility)
+    {
+      var visibility = minimumElementVisibility ?? ElementVisibility.FullyVisible;
+
+      if (resolvedElement.ElementVisibility < visibility)
+      {
+        throw new InvalidOperationException (
+            string.Format (
+                "The visibility of the resolved element is smaller than the specified minimum visibility. (visibility: {0}; required: {1})",
+                resolvedElement.ElementVisibility,
+                ElementVisibility.FullyVisible));
+      }
+
+      if (resolvedElement.ElementBounds.Width == 0 || resolvedElement.ElementBounds.Height == 0)
+        throw new InvalidOperationException ("The specified target is empty.");
+
+      if (!_screenshotBounds.Any (b => b.Contains (resolvedElement.ElementBounds)))
+        throw new InvalidOperationException ("The specified target is not part of the screenshot.");
+    }
+
+    private ScreenshotTransformationHelper<T> CreateTransformationHelper<T> (
+        ScreenshotManipulation manipulation,
+        IScreenshotElementResolver<T> resolver,
+        T target,
+        [CanBeNull] IScreenshotTransformation<T> transformation)
+    {
+      return new ScreenshotTransformationHelper<T> (
+          manipulation,
+          _layerGraphics,
+          resolver,
+          target,
+          _coordinateSystem,
+          transformation ?? EmptyTransformation<T>.Instance,
+          _locator);
+    }
+  }
+}

--- a/Remotion/Web/Development.WebTesting/ScreenshotCreation/ScreenshotTransformationHelper.cs
+++ b/Remotion/Web/Development.WebTesting/ScreenshotCreation/ScreenshotTransformationHelper.cs
@@ -1,0 +1,82 @@
+﻿// This file is part of the re-motion Core Framework (www.re-motion.org)
+// Copyright (c) rubicon IT GmbH, www.rubicon.eu
+// 
+// The re-motion Core Framework is free software; you can redistribute it 
+// and/or modify it under the terms of the GNU Lesser General Public License 
+// as published by the Free Software Foundation; either version 2.1 of the 
+// License, or (at your option) any later version.
+// 
+// re-motion is distributed in the hope that it will be useful, 
+// but WITHOUT ANY WARRANTY; without even the implied warranty of 
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public License
+// along with re-motion; if not, see http://www.gnu.org/licenses.
+// 
+using System;
+using System.Drawing;
+
+namespace Remotion.Web.Development.WebTesting.ScreenshotCreation
+{
+  internal class ScreenshotTransformationHelper<T> : IDisposable
+  {
+    private readonly ScreenshotTransformationContext<T> _context;
+    private readonly IScreenshotTransformation<T> _transformation;
+
+    public ScreenshotTransformationHelper (
+        ScreenshotManipulation manipulation,
+        Graphics graphics,
+        IScreenshotElementResolver<T> resolver,
+        T target,
+        CoordinateSystem coordinateSystem,
+        IScreenshotTransformation<T> transformation,
+        IBrowserContentLocator locator)
+    {
+      var resolvedElement = Resolve (resolver, target, locator, coordinateSystem);
+      var context = new ScreenshotTransformationContext<T> (manipulation, graphics, resolver, target, resolvedElement);
+
+      context = transformation.BeginApply (context);
+
+      var parentBounds = context.ResolvedElement.ParentBounds;
+      if (parentBounds.HasValue)
+      {
+        _context = context.CloneWith (
+            resolvedElement: resolvedElement.CloneWith (elementBounds: Rectangle.Intersect (parentBounds.Value, context.ResolvedElement.ElementBounds)));
+      }
+      else
+      {
+        _context = context;
+      }
+
+      _transformation = transformation;
+    }
+
+    public ScreenshotTransformationContext<T> Context
+    {
+      get { return _context; }
+    }
+
+    public void Dispose ()
+    {
+      _transformation.EndApply (_context);
+    }
+
+    private ResolvedScreenshotElement Resolve (
+        IScreenshotElementResolver<T> resolver,
+        T target,
+        IBrowserContentLocator locator,
+        CoordinateSystem coordinateSystem)
+    {
+      switch (coordinateSystem)
+      {
+        case CoordinateSystem.Browser:
+          return resolver.ResolveBrowserCoordinates (target);
+        case CoordinateSystem.Desktop:
+          return resolver.ResolveDesktopCoordinates (target, locator);
+        default:
+          throw new ArgumentOutOfRangeException ("coordinateSystem", coordinateSystem, null);
+      }
+    }
+  }
+}

--- a/Remotion/Web/Development.WebTesting/Web.Development.WebTesting.csproj
+++ b/Remotion/Web/Development.WebTesting/Web.Development.WebTesting.csproj
@@ -162,11 +162,13 @@
     <Compile Include="ScreenshotCreation\Resolvers\RectangleResolver.cs" />
     <Compile Include="ScreenshotCreation\Resolvers\WebElementResolver.cs" />
     <Compile Include="ScreenshotCreation\Screenshot.cs" />
+    <Compile Include="ScreenshotCreation\ScreenshotLayer.cs" />
     <Compile Include="ScreenshotCreation\ScreenshotManipulation.cs" />
     <Compile Include="ScreenshotCreation\ScreenshotBuilder.cs" />
     <Compile Include="ScreenshotCreation\ScreenshotCropping.cs" />
     <Compile Include="ScreenshotCreation\ScreenshotTransformationContext.cs" />
     <Compile Include="ScreenshotCreation\ScreenshotTransformationCollection.cs" />
+    <Compile Include="ScreenshotCreation\ScreenshotTransformationHelper.cs" />
     <Compile Include="ScreenshotCreation\Transformations\FluentTransformation.cs" />
     <Compile Include="ScreenshotCreation\Transformations\EmptyTransformation.cs" />
     <Compile Include="ScreenshotCreation\WebPadding.cs" />


### PR DESCRIPTION
Breaking Changes:

- `ScreenshotBuilder` implements `IDisposable` now and therefore needs to be disposed manually.