### PR TITLE
RM-7228: BocControlObject.GetValidationErrors throws exception with wrong messages

### DIFF
--- a/Remotion/ObjectBinding/Web.Development.WebTesting/ControlObjects/BocControlObject.cs
+++ b/Remotion/ObjectBinding/Web.Development.WebTesting/ControlObjects/BocControlObject.cs
@@ -44,7 +44,7 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.ControlObjects
     /// </summary>
     public bool IsReadOnly ()
     {
-      return Scope.GetAttributeOrThrow (DiagnosticMetadataAttributes.IsReadOnly) == "true";
+      return Scope.GetAttribute (DiagnosticMetadataAttributes.IsReadOnly) == "true";
     }
 
     /// <summary>
@@ -52,7 +52,7 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.ControlObjects
     /// </summary>
     public bool IsDisabled ()
     {
-      return Scope.GetAttributeOrThrow (DiagnosticMetadataAttributes.IsDisabled) == "true";
+      return Scope.GetAttribute (DiagnosticMetadataAttributes.IsDisabled) == "true";
     }
 
     /// <summary>
@@ -73,7 +73,7 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.ControlObjects
 
       try
       {
-        describedBy = scope.GetAttributeOrThrow ("aria-describedby");
+        describedBy = scope.GetAttribute ("aria-describedby");
       }
       catch (MissingHtmlException exception)
       {
@@ -82,7 +82,7 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.ControlObjects
 
       var validationErrorIDs = describedBy.Split (new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 
-      var validationErrorIndex = int.Parse (scope.GetAttributeOrThrow (DiagnosticMetadataAttributes.ValidationErrorIDIndex));
+      var validationErrorIndex = int.Parse (scope.GetAttribute (DiagnosticMetadataAttributes.ValidationErrorIDIndex));
       var validationErrorsScope = Scope.FindId (validationErrorIDs[validationErrorIndex]);
 
       // re-motion renders the delimiter as <br />, but the browser (and Selenium) show it as <br>

--- a/Remotion/ObjectBinding/Web.Development.WebTesting/ControlObjects/BocControlObject.cs
+++ b/Remotion/ObjectBinding/Web.Development.WebTesting/ControlObjects/BocControlObject.cs
@@ -77,7 +77,7 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.ControlObjects
       }
       catch (MissingHtmlException exception)
       {
-        throw GetMissingValidationErrorFieldException (exception);
+        throw CreateMissingValidationErrorFieldException (exception);
       }
 
       var validationErrorIDs = describedBy.Split (new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
@@ -94,11 +94,11 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.ControlObjects
       }
       catch (MissingHtmlException exception)
       {
-        throw GetMissingValidationErrorFieldException (exception);
+        throw CreateMissingValidationErrorFieldException (exception);
       }
     }
 
-    private MissingHtmlException GetMissingValidationErrorFieldException (MissingHtmlException innerException)
+    private MissingHtmlException CreateMissingValidationErrorFieldException (MissingHtmlException innerException)
     {
       return new MissingHtmlException (
           "Could not find validation error field. This could be due to wrong markup or a missing validator.",

--- a/Remotion/ObjectBinding/Web.Development.WebTesting/ControlObjects/BocControlObject.cs
+++ b/Remotion/ObjectBinding/Web.Development.WebTesting/ControlObjects/BocControlObject.cs
@@ -44,7 +44,7 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.ControlObjects
     /// </summary>
     public bool IsReadOnly ()
     {
-      return Scope[DiagnosticMetadataAttributes.IsReadOnly] == "true";
+      return Scope.GetAttributeOrThrow (DiagnosticMetadataAttributes.IsReadOnly) == "true";
     }
 
     /// <summary>
@@ -52,7 +52,7 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.ControlObjects
     /// </summary>
     public bool IsDisabled ()
     {
-      return Scope[DiagnosticMetadataAttributes.IsDisabled] == "true";
+      return Scope.GetAttributeOrThrow (DiagnosticMetadataAttributes.IsDisabled) == "true";
     }
 
     /// <summary>
@@ -69,39 +69,40 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.ControlObjects
       if (IsValid (scope))
         return new List<string>();
 
-      ElementScope validationErrorsScope;
       string describedBy;
 
       try
       {
-        describedBy = scope["aria-describedby"];
+        describedBy = scope.GetAttributeOrThrow ("aria-describedby");
       }
       catch (MissingHtmlException exception)
       {
-        throw new MissingHtmlException (
-            "Could not find validation error field. This could be due to wrong markup or a missing validators.",
-            exception);
+        throw GetMissingValidationErrorFieldException (exception);
       }
 
       var validationErrorIDs = describedBy.Split (new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 
-      try
-      {
-        var validationErrorIndex = int.Parse (scope[DiagnosticMetadataAttributes.ValidationErrorIDIndex]);
-
-        validationErrorsScope = Scope.FindId (validationErrorIDs[validationErrorIndex]);
-      }
-      catch (MissingHtmlException exception)
-      {
-        throw new MissingHtmlException (
-            "Could not find validation error field. This could be due to wrong markup or a missing validators.",
-            exception);
-      }
+      var validationErrorIndex = int.Parse (scope.GetAttributeOrThrow (DiagnosticMetadataAttributes.ValidationErrorIDIndex));
+      var validationErrorsScope = Scope.FindId (validationErrorIDs[validationErrorIndex]);
 
       // re-motion renders the delimiter as <br />, but the browser (and Selenium) show it as <br>
       const string validationErrorDelimiter = "<br>";
 
-      return validationErrorsScope.InnerHTML.Split (new[] { validationErrorDelimiter }, StringSplitOptions.RemoveEmptyEntries);
+      try
+      {
+        return validationErrorsScope.InnerHTML.Split (new[] { validationErrorDelimiter }, StringSplitOptions.RemoveEmptyEntries);
+      }
+      catch (MissingHtmlException exception)
+      {
+        throw GetMissingValidationErrorFieldException (exception);
+      }
+    }
+
+    private MissingHtmlException GetMissingValidationErrorFieldException (MissingHtmlException innerException)
+    {
+      return new MissingHtmlException (
+          "Could not find validation error field. This could be due to wrong markup or a missing validator.",
+          innerException);
     }
 
     private static bool IsValid (ElementScope scope)

--- a/Remotion/Web/Development.WebTesting/CoypuElementScopeExtensions.cs
+++ b/Remotion/Web/Development.WebTesting/CoypuElementScopeExtensions.cs
@@ -249,11 +249,11 @@ namespace Remotion.Web.Development.WebTesting
     }
 
     /// <summary>
-    /// Gets an attribute from the scope or throws a <see cref="MissingHtmlException"/> if it could not be found. Wraps <see cref="ElementScope.this"/>.
+    /// Gets the specified HTML attribute's value from the <paramref name="scope"/>.
     /// </summary>
     /// <remarks>
     /// Accessing HTML attributes through <see cref="ElementScope.this"/> returns null if the attribute does not exist.
-    /// This might not be the desired behavior in some cases, thus offering this extension method.
+    /// By using <see cref="GetAttribute"/> instead, a <see cref="MissingHtmlException"/> is thrown if the HTML attribute does not exist on the scope.
     /// </remarks>
     /// <exception cref="MissingHtmlException">If the attribute cannot be found.</exception>
     [NotNull]

--- a/Remotion/Web/Development.WebTesting/CoypuElementScopeExtensions.cs
+++ b/Remotion/Web/Development.WebTesting/CoypuElementScopeExtensions.cs
@@ -248,5 +248,25 @@ namespace Remotion.Web.Development.WebTesting
 
       Cursor.Position = new Point (0, 0);
     }
+
+    /// <summary>
+    /// Gets an attribute from the scope or throws a <see cref="MissingHtmlException"/> if it could not be found. Wraps <see cref="ElementScope.this"/>.
+    /// </summary>
+    /// <remarks>
+    /// Accessing HTML attributes through <see cref="ElementScope.this"/> returns null if the attribute does not exist.
+    /// This might not be the desired behavior in some cases, thus offering this extension method.
+    /// </remarks>
+    /// <exception cref="MissingHtmlException">If the attribute cannot be found.</exception>
+    [NotNull]
+    public static string GetAttributeOrThrow ([NotNull] this ElementScope scope, [NotNull] string attributeName)
+    {
+      ArgumentUtility.CheckNotNull ("scope", scope);
+      ArgumentUtility.CheckNotNullOrEmpty ("attributeName", attributeName);
+
+      var result = scope[attributeName]
+                   ?? throw new MissingHtmlException ($"Cannot find the attribute '{attributeName}' on the current scope.");
+
+      return result;
+    }
   }
 }

--- a/Remotion/Web/Development.WebTesting/CoypuElementScopeExtensions.cs
+++ b/Remotion/Web/Development.WebTesting/CoypuElementScopeExtensions.cs
@@ -252,7 +252,7 @@ namespace Remotion.Web.Development.WebTesting
     /// Gets the specified HTML attribute's value from the <paramref name="scope"/>.
     /// </summary>
     /// <remarks>
-    /// Accessing HTML attributes through <see cref="ElementScope.this"/> returns null if the attribute does not exist.
+    /// Accessing HTML attributes through <see cref="ElementScope.this"/> returns <see langword="null"/> if the attribute does not exist.
     /// By using <see cref="GetAttribute"/> instead, a <see cref="MissingHtmlException"/> is thrown if the HTML attribute does not exist on the scope.
     /// </remarks>
     /// <exception cref="MissingHtmlException">If the attribute cannot be found.</exception>

--- a/Remotion/Web/Development.WebTesting/CoypuElementScopeExtensions.cs
+++ b/Remotion/Web/Development.WebTesting/CoypuElementScopeExtensions.cs
@@ -99,7 +99,6 @@ namespace Remotion.Web.Development.WebTesting
         }
 
         return true;
-        
       }
       catch (MissingHtmlException)
       {
@@ -258,13 +257,15 @@ namespace Remotion.Web.Development.WebTesting
     /// </remarks>
     /// <exception cref="MissingHtmlException">If the attribute cannot be found.</exception>
     [NotNull]
-    public static string GetAttributeOrThrow ([NotNull] this ElementScope scope, [NotNull] string attributeName)
+    public static string GetAttribute ([NotNull] this ElementScope scope, [NotNull] string attributeName)
     {
       ArgumentUtility.CheckNotNull ("scope", scope);
       ArgumentUtility.CheckNotNullOrEmpty ("attributeName", attributeName);
 
-      var result = scope[attributeName]
-                   ?? throw new MissingHtmlException ($"Cannot find the attribute '{attributeName}' on the current scope.");
+      var result = scope[attributeName];
+
+      if (result == null)
+        throw new MissingHtmlException ($"Cannot find the attribute '{attributeName}' on the current scope.");
 
       return result;
     }


### PR DESCRIPTION
The changes in `BocControlObject` & `CoypuElementScopeExtensions` belong to [RM-7228](https://re-motion.atlassian.net/browse/RM-7228). The changes in the other files may need a corresponding followup issue (https://github.com/re-motion/Trunk-SVN2Git/pull/11#pullrequestreview-279597357).