### PR TITLE
RM-6942: DiagnosticMetadataAttribute BocListCellContents is not rendered when value is null

### DIFF
--- a/Remotion/ObjectBinding/Core/BusinessObjectPropertyPaths/Results/IBusinessObjectPropertyPathResult.cs
+++ b/Remotion/ObjectBinding/Core/BusinessObjectPropertyPaths/Results/IBusinessObjectPropertyPathResult.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using JetBrains.Annotations;
 
 namespace Remotion.ObjectBinding.BusinessObjectPropertyPaths.Results
 {
@@ -30,6 +31,7 @@ namespace Remotion.ObjectBinding.BusinessObjectPropertyPaths.Results
     /// The <see cref="Object"/> returned for the <see cref="ResultProperty"/> of the <see cref="ResultObject"/>
     /// or <see langword="null" /> if there is no value.
     /// </returns>
+    [CanBeNull]
     object GetValue ();
 
     /// <summary>
@@ -39,16 +41,19 @@ namespace Remotion.ObjectBinding.BusinessObjectPropertyPaths.Results
     /// The <see cref="String"/>-representation of the value returned for the <see cref="ResultProperty"/> of the <see cref="ResultObject"/> 
     /// or an empty string if there is no value.
     /// </returns>
+    [NotNull]
     string GetString (string format);
 
     /// <summary>
     /// Gets the last property of the property path, i.e. the property used to access the value.
     /// </summary>
+    [CanBeNull]
     IBusinessObjectProperty ResultProperty { get; }
     
     /// <summary>
     /// Gets the <see cref="IBusinessObject"/> that holds the value of the property path.
     /// </summary>
+    [CanBeNull]
     IBusinessObject ResultObject { get; }
   }
 }

--- a/Remotion/ObjectBinding/Web.Contracts.DiagnosticMetadata/DiagnosticMetadataAttributesForObjectBinding.cs
+++ b/Remotion/ObjectBinding/Web.Contracts.DiagnosticMetadata/DiagnosticMetadataAttributesForObjectBinding.cs
@@ -42,7 +42,7 @@ namespace Remotion.ObjectBinding.Web.Contracts.DiagnosticMetadata
 
     public static readonly string BocListCellContents = "data-boclist-cell-contents";
     public static readonly string BocListCellIndex = "data-boclist-cell-index";
-    public static readonly string BocListColumnHasDiagnosticMetadata = "data-boclist-column-has-dma";
+    public static readonly string BocListColumnHasContentAttribute = "data-boclist-column-has-content-attribute";
     // Note: do not change value without chaning usages in JavaScript files.
     public static readonly string BocListHasFakeTableHead = "data-boclist-has-fake-table-head";
     // Note: do not change value without chaning usages in JavaScript files.

--- a/Remotion/ObjectBinding/Web.Development.WebTesting.IntegrationTests/BocListControlObjectTest.cs
+++ b/Remotion/ObjectBinding/Web.Development.WebTesting.IntegrationTests/BocListControlObjectTest.cs
@@ -412,7 +412,7 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.IntegrationTests
       var bocList = home.Lists().GetByLocalID ("JobList_Normal");
       Assert.That (
           bocList.GetColumnDefinitions().Select (cd => cd.Title),
-          Is.EquivalentTo (new[] { "I_ndex", null, null, "Command", "Menu", "Title", "StartDate", "EndDate", "DisplayName", "TitleWithCmd" }));
+          Is.EquivalentTo (new[] { "I_ndex", null, "", "Command", "Menu", "Title", "StartDate", "EndDate", "DisplayName", "TitleWithCmd" }));
     }
 
     [Test]

--- a/Remotion/ObjectBinding/Web.Development.WebTesting/ControlObjects/BocListControlObjectBase.cs
+++ b/Remotion/ObjectBinding/Web.Development.WebTesting/ControlObjects/BocListControlObjectBase.cs
@@ -118,7 +118,7 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.ControlObjects
                           s[DiagnosticMetadataAttributes.Content],
                           s[DiagnosticMetadataAttributesForObjectBinding.HasPropertyPaths] == "true",
                           s[DiagnosticMetadataAttributesForObjectBinding.BoundPropertyPaths]?.Split ('\u001e'),
-                          ColumnHasDiagnosticMetadata (s)))
+                          ColumnHasContentAttribute (s)))
               .ToList());
     }
 
@@ -454,7 +454,7 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.ControlObjects
       return Scope;
     }
 
-    private bool ColumnHasDiagnosticMetadata (ElementScope scope)
+    private bool ColumnHasContentAttribute (ElementScope scope)
     {
       if (scope[DiagnosticMetadataAttributesForObjectBinding.BocListColumnHasContentAttribute] == null)
         return false;

--- a/Remotion/ObjectBinding/Web.Development.WebTesting/ControlObjects/BocListControlObjectBase.cs
+++ b/Remotion/ObjectBinding/Web.Development.WebTesting/ControlObjects/BocListControlObjectBase.cs
@@ -456,10 +456,10 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.ControlObjects
 
     private bool ColumnHasDiagnosticMetadata (ElementScope scope)
     {
-      if (scope[DiagnosticMetadataAttributesForObjectBinding.BocListColumnHasDiagnosticMetadata] == null)
+      if (scope[DiagnosticMetadataAttributesForObjectBinding.BocListColumnHasContentAttribute] == null)
         return false;
 
-      return bool.Parse (scope[DiagnosticMetadataAttributesForObjectBinding.BocListColumnHasDiagnosticMetadata]);
+      return bool.Parse (scope[DiagnosticMetadataAttributesForObjectBinding.BocListColumnHasContentAttribute]);
     }
 
     private void EnsureBocListHasBeenFullyInitialized ()

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBaseTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBaseTest.cs
@@ -209,6 +209,44 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
       Html.AssertAttribute (th, DiagnosticMetadataAttributesForObjectBinding.BocListColumnHasDiagnosticMetadata, "true");
     }
 
+    [Test]
+    public void TestDiagnosticMetadataRenderingInTitleForEmptyContent ()
+    {
+      IBocColumnRenderer renderer = new BocSimpleColumnRenderer (
+          new FakeResourceUrlFactory(),
+          RenderingFeatures.WithDiagnosticMetadata,
+          _bocListCssClassDefinition);
+
+      Column.ColumnTitle = "";
+
+      var renderingContext = CreateRenderingContext();
+
+      renderer.RenderTitleCell (renderingContext, SortingDirection.None, 0);
+
+      var document = Html.GetResultDocument();
+      var th = Html.GetAssertedChildElement (document, "th", 0);
+      Html.AssertAttribute (th, DiagnosticMetadataAttributes.Content, Column.ColumnTitleDisplayValue);
+    }
+
+    [Test]
+    public void TestDiagnosticMetadataRenderingInTitleForNullContent ()
+    {
+      IBocColumnRenderer renderer = new BocSimpleColumnRenderer (
+          new FakeResourceUrlFactory(),
+          RenderingFeatures.WithDiagnosticMetadata,
+          _bocListCssClassDefinition);
+
+      Column.ColumnTitle = null;
+
+      var renderingContext = CreateRenderingContext();
+
+      renderer.RenderTitleCell (renderingContext, SortingDirection.None, 0);
+
+      var document = Html.GetResultDocument();
+      var th = Html.GetAssertedChildElement (document, "th", 0);
+      Html.AssertAttribute (th, DiagnosticMetadataAttributes.Content, Column.ColumnTitleDisplayValue);
+    }
+
     private void RenderTitleCell (
         SortingDirection sortDirection,
         int sortIndex,

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBaseTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBaseTest.cs
@@ -206,7 +206,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
       Html.AssertAttribute (th, DiagnosticMetadataAttributes.ItemID, Column.ItemID);
       Html.AssertAttribute (th, DiagnosticMetadataAttributes.Content, Column.ColumnTitleDisplayValue);
       Html.AssertAttribute (th, DiagnosticMetadataAttributesForObjectBinding.BocListCellIndex, 7.ToString());
-      Html.AssertAttribute (th, DiagnosticMetadataAttributesForObjectBinding.BocListColumnHasDiagnosticMetadata, "true");
+      Html.AssertAttribute (th, DiagnosticMetadataAttributesForObjectBinding.BocListColumnHasContentAttribute, "true");
     }
 
     [Test]

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBaseTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBaseTest.cs
@@ -212,10 +212,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
     [Test]
     public void TestDiagnosticMetadataRenderingInTitleForEmptyContent ()
     {
-      IBocColumnRenderer renderer = new BocSimpleColumnRenderer (
-          new FakeResourceUrlFactory(),
-          RenderingFeatures.WithDiagnosticMetadata,
-          _bocListCssClassDefinition);
+      IBocColumnRenderer renderer = new BocSimpleColumnRenderer (new FakeResourceUrlFactory(), RenderingFeatures.WithDiagnosticMetadata, _bocListCssClassDefinition);
 
       Column.ColumnTitle = "";
 
@@ -231,10 +228,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
     [Test]
     public void TestDiagnosticMetadataRenderingInTitleForNullContent ()
     {
-      IBocColumnRenderer renderer = new BocSimpleColumnRenderer (
-          new FakeResourceUrlFactory(),
-          RenderingFeatures.WithDiagnosticMetadata,
-          _bocListCssClassDefinition);
+      IBocColumnRenderer renderer = new BocSimpleColumnRenderer (new FakeResourceUrlFactory(), RenderingFeatures.WithDiagnosticMetadata, _bocListCssClassDefinition);
 
       Column.ColumnTitle = null;
 

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBaseTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBaseTest.cs
@@ -221,7 +221,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
       var document = Html.GetResultDocument();
       var th = Html.GetAssertedChildElement (document, "th", 0);
       Assert.That (Column.ColumnTitleDisplayValue, Is.Empty);
-      Html.AssertAttribute (th, DiagnosticMetadataAttributes.Content, Column.ColumnTitleDisplayValue);
+      Html.AssertAttribute (th, DiagnosticMetadataAttributes.Content, string.Empty);
     }
 
     [Test]
@@ -236,7 +236,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
       var document = Html.GetResultDocument();
       var th = Html.GetAssertedChildElement (document, "th", 0);
       Assert.That (Column.ColumnTitleDisplayValue, Is.Empty);
-      Html.AssertAttribute (th, DiagnosticMetadataAttributes.Content, Column.ColumnTitleDisplayValue);
+      Html.AssertAttribute (th, DiagnosticMetadataAttributes.Content, string.Empty);
     }
 
     private void RenderTitleCell (

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBaseTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBaseTest.cs
@@ -220,6 +220,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
 
       var document = Html.GetResultDocument();
       var th = Html.GetAssertedChildElement (document, "th", 0);
+      Assert.That (Column.ColumnTitleDisplayValue, Is.Empty);
       Html.AssertAttribute (th, DiagnosticMetadataAttributes.Content, Column.ColumnTitleDisplayValue);
     }
 
@@ -234,6 +235,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
 
       var document = Html.GetResultDocument();
       var th = Html.GetAssertedChildElement (document, "th", 0);
+      Assert.That (Column.ColumnTitleDisplayValue, Is.Empty);
       Html.AssertAttribute (th, DiagnosticMetadataAttributes.Content, Column.ColumnTitleDisplayValue);
     }
 

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBaseTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBaseTest.cs
@@ -210,7 +210,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
     }
 
     [Test]
-    public void TestDiagnosticMetadataRenderingInTitleForEmptyContent ()
+    public void TestDiagnosticMetadataRenderingWithTitleIsEmpty ()
     {
       IBocColumnRenderer renderer = new BocSimpleColumnRenderer (new FakeResourceUrlFactory(), RenderingFeatures.WithDiagnosticMetadata, _bocListCssClassDefinition);
 
@@ -226,7 +226,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
     }
 
     [Test]
-    public void TestDiagnosticMetadataRenderingInTitleForNullContent ()
+    public void TestDiagnosticMetadataRenderingInTitleWithTitleIsNull ()
     {
       IBocColumnRenderer renderer = new BocSimpleColumnRenderer (new FakeResourceUrlFactory(), RenderingFeatures.WithDiagnosticMetadata, _bocListCssClassDefinition);
 

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBaseTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBaseTest.cs
@@ -213,9 +213,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
     public void TestDiagnosticMetadataRenderingWithTitleIsEmpty ()
     {
       IBocColumnRenderer renderer = new BocSimpleColumnRenderer (new FakeResourceUrlFactory(), RenderingFeatures.WithDiagnosticMetadata, _bocListCssClassDefinition);
-
       Column.ColumnTitle = "";
-
       var renderingContext = CreateRenderingContext();
 
       renderer.RenderTitleCell (renderingContext, SortingDirection.None, 0);
@@ -229,9 +227,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
     public void TestDiagnosticMetadataRenderingInTitleWithTitleIsNull ()
     {
       IBocColumnRenderer renderer = new BocSimpleColumnRenderer (new FakeResourceUrlFactory(), RenderingFeatures.WithDiagnosticMetadata, _bocListCssClassDefinition);
-
       Column.ColumnTitle = null;
-
       var renderingContext = CreateRenderingContext();
 
       renderer.RenderTitleCell (renderingContext, SortingDirection.None, 0);

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocCompoundColumnRendererTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocCompoundColumnRendererTest.cs
@@ -112,6 +112,25 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
     }
 
     [Test]
+    public void RenderCell_WithNullAsContent ()
+    {
+      var businessObject = TypeWithReference.Create();
+      EventArgs = new BocListDataRowRenderEventArgs (10, (IBusinessObject) businessObject, false, true);
+      Column.PropertyPathBindings.Clear();
+      Column.PropertyPathBindings.Add (new PropertyPathBinding ("ReferenceValue"));
+      IBocColumnRenderer renderer = new BocCompoundColumnRenderer (new FakeResourceUrlFactory(), RenderingFeatures.WithDiagnosticMetadata, _bocListCssClassDefinition);
+
+      renderer.RenderDataCell (_renderingContext, 0, false, EventArgs);
+
+      Assert.That (businessObject.ReferenceValue, Is.Null);
+      var document = Html.GetResultDocument();
+      var td = Html.GetAssertedChildElement (document, "td", 0);
+      var span = Html.GetAssertedChildElement (td, "span", 0);
+      var textWrapper = Html.GetAssertedChildElement (span, "span", 0);
+      Html.AssertAttribute (textWrapper, DiagnosticMetadataAttributesForObjectBinding.BocListCellContents, string.Empty);
+    }
+
+    [Test]
     public void RenderBasicCell_WithNewLineAndEncoding ()
     {
       IBocColumnRenderer renderer = new BocCompoundColumnRenderer (new FakeResourceUrlFactory(), RenderingFeatures.Default, _bocListCssClassDefinition);

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocCompoundColumnRendererTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocCompoundColumnRendererTest.cs
@@ -18,6 +18,7 @@ using System;
 using System.Web.UI.WebControls;
 using NUnit.Framework;
 using Remotion.Development.Web.UnitTesting.Resources;
+using Remotion.ObjectBinding.Web.Contracts.DiagnosticMetadata;
 using Remotion.ObjectBinding.Web.Services;
 using Remotion.ObjectBinding.Web.UI.Controls;
 using Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering;
@@ -92,6 +93,22 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
 
       var textWrapper = Html.GetAssertedChildElement (span, "span", 0);
       Html.AssertTextNode (textWrapper, "referencedObject1", 0);
+    }
+
+    [Test]
+    public void RenderCell_WithEmptyDisplayName ()
+    {
+      var businessObject = TypeWithReference.Create ("");
+      EventArgs = new BocListDataRowRenderEventArgs (10, (IBusinessObject) businessObject, false, true);
+      IBocColumnRenderer renderer = new BocCompoundColumnRenderer (new FakeResourceUrlFactory(), RenderingFeatures.WithDiagnosticMetadata, _bocListCssClassDefinition);
+
+      renderer.RenderDataCell (_renderingContext, 0, false, EventArgs);
+
+      var document = Html.GetResultDocument();
+      var td = Html.GetAssertedChildElement (document, "td", 0);
+      var span = Html.GetAssertedChildElement (td, "span", 0);
+      var textWrapper = Html.GetAssertedChildElement (span, "span", 0);
+      Html.AssertAttribute (textWrapper, DiagnosticMetadataAttributesForObjectBinding.BocListCellContents, string.Empty);
     }
 
     [Test]

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocSimpleColumnRendererTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocSimpleColumnRendererTest.cs
@@ -212,5 +212,37 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
               0,
               List.ClientID + "_0_Title"));
     }
+
+    [Test]
+    public void RenderEditModeControl_HasDiagnosticMetadata ()
+    {
+      var firstObject = (IBusinessObject) ((TypeWithReference) BusinessObject).FirstValue;
+
+      IEditableRow editableRow = MockRepository.GenerateMock<IEditableRow>();
+      editableRow.Stub (mock => mock.HasEditControl (0)).IgnoreArguments().Return (true);
+      editableRow.Stub (mock => mock.GetEditControl (0)).IgnoreArguments().Return (MockRepository.GenerateStub<IBocTextValue>());
+
+      List.EditModeController.Stub (mock => mock.GetEditableRow (EventArgs.ListIndex)).Return (editableRow);
+
+      IBocColumnRenderer renderer = new BocSimpleColumnRenderer (new FakeResourceUrlFactory(), RenderingFeatures.WithDiagnosticMetadata, _bocListCssClassDefinition);
+      renderer.RenderDataCell (_renderingContext, 0, false, EventArgs);
+
+      var document = Html.GetResultDocument();
+
+      var td = Html.GetAssertedChildElement (document, "td", 0);
+      Html.AssertAttribute (td, DiagnosticMetadataAttributesForObjectBinding.BocListCellIndex, "1");
+      var span = Html.GetAssertedChildElement (td, "span", 0);
+      var clickSpan = Html.GetAssertedChildElement (span, "span", 0);
+      Html.AssertAttribute (clickSpan, "onclick", "BocList_OnCommandClick();");
+      Html.AssertAttribute (clickSpan, DiagnosticMetadataAttributesForObjectBinding.BocListCellContents, "referencedObject1");
+
+      editableRow.AssertWasCalled (
+          mock => mock.RenderSimpleColumnCellEditModeControl (
+              Html.Writer,
+              Column,
+              firstObject,
+              0,
+              List.ClientID + "_0_Title"));
+    }
   }
 }

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocSimpleColumnRendererTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocSimpleColumnRendererTest.cs
@@ -15,8 +15,6 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
-using System.Collections.Generic;
-using System.Web.UI;
 using NUnit.Framework;
 using Remotion.Development.Web.UnitTesting.Resources;
 using Remotion.ObjectBinding.Web.Contracts.DiagnosticMetadata;
@@ -87,6 +85,24 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
 
       renderer.RenderDataCell (_renderingContext, 0, false, EventArgs);
 
+      var document = Html.GetResultDocument();
+      var td = Html.GetAssertedChildElement (document, "td", 0);
+      var span = Html.GetAssertedChildElement (td, "span", 0);
+      var textWrapper = Html.GetAssertedChildElement (span, "span", 0);
+      Html.AssertAttribute (textWrapper, DiagnosticMetadataAttributesForObjectBinding.BocListCellContents, string.Empty);
+    }
+
+    [Test]
+    public void RenderCell_WithNullAsContent ()
+    {
+      var businessObject = TypeWithReference.Create();
+      EventArgs = new BocListDataRowRenderEventArgs (10, (IBusinessObject) businessObject, false, true);
+      Column.PropertyPathIdentifier = "ReferenceValue";
+      IBocColumnRenderer renderer = new BocSimpleColumnRenderer (new FakeResourceUrlFactory(), RenderingFeatures.WithDiagnosticMetadata, _bocListCssClassDefinition);
+
+      renderer.RenderDataCell (_renderingContext, 0, false, EventArgs);
+
+      Assert.That (businessObject.ReferenceValue, Is.Null);
       var document = Html.GetResultDocument();
       var td = Html.GetAssertedChildElement (document, "td", 0);
       var span = Html.GetAssertedChildElement (td, "span", 0);

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocSimpleColumnRendererTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocSimpleColumnRendererTest.cs
@@ -77,7 +77,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
     }
 
     [Test]
-    public void RenderCell_WithEmptyDisplayName ()
+    public void TestDiagnosticMetadataRenderingWithEmptyDisplayName ()
     {
       var businessObject = TypeWithReference.Create ("");
       EventArgs = new BocListDataRowRenderEventArgs (10, (IBusinessObject) businessObject, false, true);
@@ -93,7 +93,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
     }
 
     [Test]
-    public void RenderCell_WithNullAsContent ()
+    public void TestDiagnosticMetadataRenderingWithNullValue ()
     {
       var businessObject = TypeWithReference.Create();
       EventArgs = new BocListDataRowRenderEventArgs (10, (IBusinessObject) businessObject, false, true);
@@ -214,7 +214,7 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
     }
 
     [Test]
-    public void RenderEditModeControl_HasDiagnosticMetadata ()
+    public void TestDiagnosticMetadataRenderingWithEditModeControl ()
     {
       var firstObject = (IBusinessObject) ((TypeWithReference) BusinessObject).FirstValue;
 

--- a/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocSimpleColumnRendererTest.cs
+++ b/Remotion/ObjectBinding/Web.UnitTests/UI/Controls/BocListImplementation/Rendering/BocSimpleColumnRendererTest.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Web.UI;
 using NUnit.Framework;
 using Remotion.Development.Web.UnitTesting.Resources;
+using Remotion.ObjectBinding.Web.Contracts.DiagnosticMetadata;
 using Remotion.ObjectBinding.Web.Services;
 using Remotion.ObjectBinding.Web.UI.Controls;
 using Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.EditableRowSupport;
@@ -75,6 +76,22 @@ namespace Remotion.ObjectBinding.Web.UnitTests.UI.Controls.BocListImplementation
 
       var textWrapper = Html.GetAssertedChildElement (span, "span", 0);
       Html.AssertTextNode (textWrapper, "referencedObject1", 0);
+    }
+
+    [Test]
+    public void RenderCell_WithEmptyDisplayName ()
+    {
+      var businessObject = TypeWithReference.Create ("");
+      EventArgs = new BocListDataRowRenderEventArgs (10, (IBusinessObject) businessObject, false, true);
+      IBocColumnRenderer renderer = new BocSimpleColumnRenderer (new FakeResourceUrlFactory(), RenderingFeatures.WithDiagnosticMetadata, _bocListCssClassDefinition);
+
+      renderer.RenderDataCell (_renderingContext, 0, false, EventArgs);
+
+      var document = Html.GetResultDocument();
+      var td = Html.GetAssertedChildElement (document, "td", 0);
+      var span = Html.GetAssertedChildElement (td, "span", 0);
+      var textWrapper = Html.GetAssertedChildElement (span, "span", 0);
+      Html.AssertAttribute (textWrapper, DiagnosticMetadataAttributesForObjectBinding.BocListCellContents, string.Empty);
     }
 
     [Test]

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBase.cs
@@ -128,7 +128,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
 
         var columnTitle = renderingContext.ColumnDefinition.ColumnTitleDisplayValue;
         if (string.IsNullOrEmpty (columnTitle))
-          renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributes.Content, "");
+          renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributes.Content, string.Empty);
         else
           renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributes.Content, HtmlUtility.StripHtmlTags (columnTitle));
 

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBase.cs
@@ -133,7 +133,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
         renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributesForObjectBinding.BocListCellIndex, oneBasedCellIndex.ToString());
 
         renderingContext.Writer.AddAttribute (
-            DiagnosticMetadataAttributesForObjectBinding.BocListColumnHasDiagnosticMetadata,
+            DiagnosticMetadataAttributesForObjectBinding.BocListColumnHasContentAttribute,
             HasDiagnoticMetadata.ToString().ToLower());
       }
       renderingContext.Writer.RenderBeginTag (HtmlTextWriterTag.Th);

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBase.cs
@@ -95,7 +95,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
     /// <summary>
     /// Returns whether the renderer is able to render diagnostic metadata.
     /// </summary>
-    protected virtual bool HasDiagnoticMetadata
+    protected virtual bool HasContentAttribute
     {
       get { return false; }
     }
@@ -134,7 +134,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
 
         renderingContext.Writer.AddAttribute (
             DiagnosticMetadataAttributesForObjectBinding.BocListColumnHasContentAttribute,
-            HasDiagnoticMetadata.ToString().ToLower());
+            HasContentAttribute.ToString().ToLower());
       }
       renderingContext.Writer.RenderBeginTag (HtmlTextWriterTag.Th);
 

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBase.cs
@@ -127,7 +127,9 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
           renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributes.ItemID, columnItemID);
 
         var columnTitle = renderingContext.ColumnDefinition.ColumnTitleDisplayValue;
-        if (!string.IsNullOrEmpty (columnTitle))
+        if (string.IsNullOrEmpty (columnTitle))
+          renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributes.Content, "");
+        else
           renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributes.Content, HtmlUtility.StripHtmlTags (columnTitle));
 
         var oneBasedCellIndex = renderingContext.VisibleColumnIndex + 1;

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocColumnRendererBase.cs
@@ -126,11 +126,8 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
         if (!string.IsNullOrEmpty (columnItemID))
           renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributes.ItemID, columnItemID);
 
-        var columnTitle = renderingContext.ColumnDefinition.ColumnTitleDisplayValue;
-        if (string.IsNullOrEmpty (columnTitle))
-          renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributes.Content, string.Empty);
-        else
-          renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributes.Content, HtmlUtility.StripHtmlTags (columnTitle));
+        var columnTitle = StringUtility.NullToEmpty (renderingContext.ColumnDefinition.ColumnTitleDisplayValue);
+        renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributes.Content, HtmlUtility.StripHtmlTags (columnTitle));
 
         var oneBasedCellIndex = renderingContext.VisibleColumnIndex + 1;
         renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributesForObjectBinding.BocListCellIndex, oneBasedCellIndex.ToString());

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocCommandEnabledColumnRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocCommandEnabledColumnRendererBase.cs
@@ -62,14 +62,8 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
       ArgumentUtility.CheckNotNull ("renderingContext", renderingContext);
 
       renderingContext.Writer.AddAttribute ("class", CssClasses.CommandText);
-      if (RenderingFeatures.EnableDiagnosticMetadata)
-      {
-        if (string.IsNullOrWhiteSpace (contents))
-          renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributesForObjectBinding.BocListCellContents, string.Empty);
-        else
-          renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributesForObjectBinding.BocListCellContents, contents);
-      }
-
+      if (RenderingFeatures.EnableDiagnosticMetadata && contents != null)
+        renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributesForObjectBinding.BocListCellContents, contents);
       renderingContext.Writer.RenderBeginTag (HtmlTextWriterTag.Span);
 
       if (string.IsNullOrWhiteSpace (contents))

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocCommandEnabledColumnRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocCommandEnabledColumnRendererBase.cs
@@ -62,8 +62,14 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
       ArgumentUtility.CheckNotNull ("renderingContext", renderingContext);
 
       renderingContext.Writer.AddAttribute ("class", CssClasses.CommandText);
-      if (RenderingFeatures.EnableDiagnosticMetadata && contents != null)
-        renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributesForObjectBinding.BocListCellContents, contents);
+      if (RenderingFeatures.EnableDiagnosticMetadata)
+      {
+        if (string.IsNullOrWhiteSpace (contents))
+          renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributesForObjectBinding.BocListCellContents, "");
+        else
+          renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributesForObjectBinding.BocListCellContents, contents);
+      }
+
       renderingContext.Writer.RenderBeginTag (HtmlTextWriterTag.Span);
 
       if (string.IsNullOrWhiteSpace (contents))

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocCommandEnabledColumnRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocCommandEnabledColumnRendererBase.cs
@@ -65,7 +65,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
       if (RenderingFeatures.EnableDiagnosticMetadata)
       {
         if (string.IsNullOrWhiteSpace (contents))
-          renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributesForObjectBinding.BocListCellContents, "");
+          renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributesForObjectBinding.BocListCellContents, string.Empty);
         else
           renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributesForObjectBinding.BocListCellContents, contents);
       }

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocCommandEnabledColumnRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocCommandEnabledColumnRendererBase.cs
@@ -16,14 +16,12 @@
 // 
 using System;
 using System.Web.UI;
-using Remotion.ObjectBinding.Web.Contracts.DiagnosticMetadata;
 using Remotion.Security;
 using Remotion.Utilities;
 using Remotion.Web;
 using Remotion.Web.UI;
 using Remotion.Web.UI.Controls;
 using Remotion.Web.UI.Controls.Rendering;
-using Remotion.Web.Utilities;
 
 namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
 {
@@ -55,24 +53,6 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
         icon.Render (renderingContext.Writer, renderingContext.Control);
         renderingContext.Writer.Write (c_whiteSpace);
       }
-    }
-
-    protected void RenderValueColumnCellText (BocColumnRenderingContext<TBocColumnDefinition> renderingContext, string contents)
-    {
-      ArgumentUtility.CheckNotNull ("renderingContext", renderingContext);
-      ArgumentUtility.CheckNotNull ("contents", contents);
-
-      renderingContext.Writer.AddAttribute ("class", CssClasses.CommandText);
-      if (RenderingFeatures.EnableDiagnosticMetadata)
-        renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributesForObjectBinding.BocListCellContents, contents);
-      renderingContext.Writer.RenderBeginTag (HtmlTextWriterTag.Span);
-
-      if (string.IsNullOrWhiteSpace (contents))
-        renderingContext.Writer.Write ("&nbsp;");
-      else
-        renderingContext.Writer.WriteEncodedLines (StringUtility.ParseNewLineSeparatedString (contents));
-
-      renderingContext.Writer.RenderEndTag();
     }
 
     protected bool RenderBeginTagDataCellCommand (

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocCommandEnabledColumnRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocCommandEnabledColumnRendererBase.cs
@@ -60,9 +60,10 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
     protected void RenderValueColumnCellText (BocColumnRenderingContext<TBocColumnDefinition> renderingContext, string contents)
     {
       ArgumentUtility.CheckNotNull ("renderingContext", renderingContext);
+      ArgumentUtility.CheckNotNull ("contents", contents);
 
       renderingContext.Writer.AddAttribute ("class", CssClasses.CommandText);
-      if (RenderingFeatures.EnableDiagnosticMetadata && contents != null)
+      if (RenderingFeatures.EnableDiagnosticMetadata)
         renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributesForObjectBinding.BocListCellContents, contents);
       renderingContext.Writer.RenderBeginTag (HtmlTextWriterTag.Span);
 

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocSimpleColumnRenderer.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocSimpleColumnRenderer.cs
@@ -129,6 +129,13 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
     {
       if (renderingContext.Control.HasClientScript)
         renderingContext.Writer.AddAttribute (HtmlTextWriterAttribute.Onclick, c_onCommandClickScript);
+
+      if (_renderingFeatures.EnableDiagnosticMetadata)
+      {
+        var contentString = renderingContext.ColumnDefinition.GetStringValue (businessObject);
+        renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributesForObjectBinding.BocListCellContents, contentString);
+      }
+
       renderingContext.Writer.RenderBeginTag (HtmlTextWriterTag.Span); // Begin span
 
       editableRow.RenderSimpleColumnCellEditModeControl (

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocValueColumnRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocValueColumnRendererBase.cs
@@ -17,11 +17,12 @@
 using System;
 using System.Web.UI;
 using System.Web.UI.WebControls;
+using Remotion.ObjectBinding.Web.Contracts.DiagnosticMetadata;
 using Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.EditableRowSupport;
 using Remotion.Utilities;
 using Remotion.Web;
-using Remotion.Web.UI.Controls;
 using Remotion.Web.UI.Controls.Rendering;
+using Remotion.Web.Utilities;
 
 namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
 {
@@ -93,6 +94,24 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
     /// <param name="businessObject">Can be used to derive the icon to render.</param>
     protected virtual void RenderOtherIcons (BocColumnRenderingContext<TBocColumnDefinition> renderingContext, IBusinessObject businessObject)
     {
+    }
+
+    protected void RenderValueColumnCellText (BocColumnRenderingContext<TBocColumnDefinition> renderingContext, string contents)
+    {
+      ArgumentUtility.CheckNotNull ("renderingContext", renderingContext);
+      ArgumentUtility.CheckNotNull ("contents", contents);
+
+      renderingContext.Writer.AddAttribute ("class", CssClasses.CommandText);
+      if (RenderingFeatures.EnableDiagnosticMetadata)
+        renderingContext.Writer.AddAttribute (DiagnosticMetadataAttributesForObjectBinding.BocListCellContents, contents);
+      renderingContext.Writer.RenderBeginTag (HtmlTextWriterTag.Span);
+
+      if (string.IsNullOrWhiteSpace (contents))
+        renderingContext.Writer.Write ("&nbsp;");
+      else
+        renderingContext.Writer.WriteEncodedLines (StringUtility.ParseNewLineSeparatedString (contents));
+
+      renderingContext.Writer.RenderEndTag();
     }
 
     /// <summary>

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocValueColumnRendererBase.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocListImplementation/Rendering/BocValueColumnRendererBase.cs
@@ -178,7 +178,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls.BocListImplementation.Rendering
     /// <summary>
     /// <see cref="BocValueColumnRendererBase{TBocColumnDefinition}"/> renders diagnostic metadata.
     /// </summary>
-    protected override bool HasDiagnoticMetadata
+    protected override bool HasContentAttribute
     {
       get { return true; }
     }

--- a/Remotion/ObjectBinding/Web/UI/Controls/BocValueColumnDefinition.cs
+++ b/Remotion/ObjectBinding/Web/UI/Controls/BocValueColumnDefinition.cs
@@ -36,6 +36,7 @@ namespace Remotion.ObjectBinding.Web.UI.Controls
     /// <summary> Creates a string representation of the data displayed in this column. </summary>
     /// <param name="obj"> The <see cref="IBusinessObject"/> to be displayed in this column. </param>
     /// <returns> A <see cref="string"/> representing the contents of <paramref name="obj"/>. </returns>
+    [NotNull]
     public abstract string GetStringValue (IBusinessObject obj);
     
     /// <summary>


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-6942