### PR TITLE
RM-7280: TestExecutionScreenshotRecorderTest.TearDown() does not check if the used path exists before accessing it

### DIFF
--- a/Remotion/Web/Development.WebTesting.IntegrationTests/TestExecutionScreenshotRecorderTest.cs
+++ b/Remotion/Web/Development.WebTesting.IntegrationTests/TestExecutionScreenshotRecorderTest.cs
@@ -43,12 +43,15 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests
     [TearDown]
     public void TearDown ()
     {
-      var files = Directory.GetFiles (_tempSavePath, "*.png");
+      if (Directory.Exists (_tempSavePath))
+      {
+        var files = Directory.GetFiles (_tempSavePath, "*.png");
 
-      foreach (var file in files)
-        File.Delete (file);
+        foreach (var file in files)
+          File.Delete (file);
 
-      Directory.Delete (_tempSavePath);
+        Directory.Delete (_tempSavePath);
+      }
 
       if (IsAlertDialogPresent ((IWebDriver) Helper.MainBrowserSession.Driver.Native))
         Helper.MainBrowserSession.Window.AcceptModalDialog();


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-7280