### PR TITLE
RM-7295: ChromeUserDirectoryCleanUpStrategy should accept the userdirectory root as string instead of the whole IChromeConfiguration

### DIFF
--- a/Remotion/Web/Development.WebTesting.UnitTests/WebDriver/Configuration/Chrome/ChromeUserDirectoryCleanUpStrategyTest.cs
+++ b/Remotion/Web/Development.WebTesting.UnitTests/WebDriver/Configuration/Chrome/ChromeUserDirectoryCleanUpStrategyTest.cs
@@ -33,9 +33,7 @@ namespace Remotion.Web.Development.WebTesting.UnitTests.WebDriver.Configuration.
       var anotherUserDirectoryPath = Path.Combine (userDirectoryRootPath, "1");
       Directory.CreateDirectory (userDirectoryPath);
       Directory.CreateDirectory (anotherUserDirectoryPath);
-      var chromeConfigurationStub = MockRepository.GenerateStub<IChromeConfiguration>();
-      chromeConfigurationStub.Stub (_ => _.UserDirectoryRoot).Return (userDirectoryRootPath);
-      var cleanUpStrategy = new ChromeUserDirectoryCleanUpStrategy (chromeConfigurationStub, userDirectoryPath);
+      var cleanUpStrategy = new ChromeUserDirectoryCleanUpStrategy (userDirectoryRootPath, userDirectoryPath);
 
       try
       {
@@ -57,9 +55,7 @@ namespace Remotion.Web.Development.WebTesting.UnitTests.WebDriver.Configuration.
       var userDirectoryRootPath = Path.Combine (Path.GetTempPath(), Guid.NewGuid().ToString ("N"));
       var userDirectoryPath = Path.Combine (userDirectoryRootPath, "0");
       Directory.CreateDirectory (userDirectoryPath);
-      var chromeConfigurationStub = MockRepository.GenerateStub<IChromeConfiguration>();
-      chromeConfigurationStub.Stub (_ => _.UserDirectoryRoot).Return (userDirectoryRootPath);
-      var cleanUpStrategy = new ChromeUserDirectoryCleanUpStrategy (chromeConfigurationStub, userDirectoryPath);
+      var cleanUpStrategy = new ChromeUserDirectoryCleanUpStrategy (userDirectoryRootPath, userDirectoryPath);
 
       try
       {

--- a/Remotion/Web/Development.WebTesting/WebDriver/Configuration/Chrome/ChromeUserDirectoryCleanUpStrategy.cs
+++ b/Remotion/Web/Development.WebTesting/WebDriver/Configuration/Chrome/ChromeUserDirectoryCleanUpStrategy.cs
@@ -30,15 +30,15 @@ namespace Remotion.Web.Development.WebTesting.WebDriver.Configuration.Chrome
   {
     private static readonly ILog s_log = LogManager.GetLogger (typeof (ChromeUserDirectoryCleanUpStrategy));
 
-    private readonly IChromeConfiguration _chromeConfiguration;
+    private readonly string _userDirectoryRoot;
     private readonly string _userDirectory;
 
-    public ChromeUserDirectoryCleanUpStrategy ([NotNull] IChromeConfiguration chromeConfiguration, [NotNull] string userDirectory)
+    public ChromeUserDirectoryCleanUpStrategy ([NotNull] string userDirectoryRoot, [NotNull] string userDirectory)
     {
-      ArgumentUtility.CheckNotNull ("chromeConfiguration", chromeConfiguration);
+      ArgumentUtility.CheckNotNullOrEmpty ("userDirectoryRoot", userDirectoryRoot);
       ArgumentUtility.CheckNotNullOrEmpty ("userDirectory", userDirectory);
 
-      _chromeConfiguration = chromeConfiguration;
+      _userDirectoryRoot = userDirectoryRoot;
       _userDirectory = userDirectory;
     }
 
@@ -104,20 +104,15 @@ namespace Remotion.Web.Development.WebTesting.WebDriver.Configuration.Chrome
     /// </summary>
     private void DeleteUserDirectoryRoot ()
     {
-      var userDirectoryRoot = _chromeConfiguration.UserDirectoryRoot;
-
-      if (string.IsNullOrEmpty (userDirectoryRoot))
+      if (!Directory.Exists (_userDirectoryRoot))
         return;
 
-      if (!Directory.Exists (userDirectoryRoot))
-        return;
-
-      if (Directory.GetDirectories (userDirectoryRoot).Length > 0)
+      if (Directory.GetDirectories (_userDirectoryRoot).Length > 0)
         return;
 
       try
       {
-        Directory.Delete (userDirectoryRoot);
+        Directory.Delete (_userDirectoryRoot);
       }
       catch (IOException)
       {

--- a/Remotion/Web/Development.WebTesting/WebDriver/Factories/Chrome/ChromeBrowserFactory.cs
+++ b/Remotion/Web/Development.WebTesting/WebDriver/Factories/Chrome/ChromeBrowserFactory.cs
@@ -66,7 +66,7 @@ namespace Remotion.Web.Development.WebTesting.WebDriver.Factories.Chrome
           new[]
           {
               registryCleanUpStrategy,
-              new ChromeUserDirectoryCleanUpStrategy (_chromeConfiguration, userDirectory)
+              new ChromeUserDirectoryCleanUpStrategy (_chromeConfiguration.UserDirectoryRoot, userDirectory)
           });
     }
 


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-7295