### PR TITLE
RM-7310: DictionaryExtensions.AsReadOnly should not instantiate a new ReadOnlyDictionary if the provided dictionary is already a ReadOnlyDictionary

### DIFF
--- a/Remotion/Core/Core/Collections/DictionaryExtensions.cs
+++ b/Remotion/Core/Core/Collections/DictionaryExtensions.cs
@@ -106,6 +106,9 @@ namespace Remotion.Collections
     {
       ArgumentUtility.CheckNotNull ("dict", dict);
 
+      if (dict is ReadOnlyDictionary<TKey, TValue> readOnlyDict)
+        return readOnlyDict;
+
       return new ReadOnlyDictionary<TKey, TValue> (dict);
     }
   }

--- a/Remotion/Core/UnitTests/Collections/DictionaryExtensionsTest.cs
+++ b/Remotion/Core/UnitTests/Collections/DictionaryExtensionsTest.cs
@@ -201,5 +201,15 @@ namespace Remotion.UnitTests.Collections
 
       Assert.That (readOnlyDictionary, Is.EqualTo (_dictionary));
     }
+
+    [Test]
+    public void AsReadOnly_WithReadOnlyDictionary_ReturnsSameInstance ()
+    {
+      var dictionary = new ReadOnlyDictionary<string, string> (_dictionary);
+
+      var readOnlyDictionary = dictionary.AsReadOnly();
+
+      Assert.That (readOnlyDictionary, Is.SameAs (dictionary));
+    }
   }
 }


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-7310 