### PR TITLE
RM-7186: Selecting children of unexpanded nodes should throw the same exception for all node types

### DIFF
--- a/Remotion/ObjectBinding/Web.Development.WebTesting.IntegrationTests/BocTreeViewControlObjectTest.cs
+++ b/Remotion/ObjectBinding/Web.Development.WebTesting.IntegrationTests/BocTreeViewControlObjectTest.cs
@@ -302,10 +302,22 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.IntegrationTests
       rootNode.Expand();
 
       rootNode.Scope.ElementFinder.Options.Timeout = TimeSpan.Zero;
-      Assert.That (() => rootNode.GetNodeInHierarchy().WithDisplayTextContains ("A, B").Select(), Throws.InstanceOf<StaleElementException>());
-      Assert.That (() => rootNode.GetNodeInHierarchy().WithDisplayText ("E, ").Select(), Throws.InstanceOf<StaleElementException>());
-      Assert.That (() => rootNode.GetNodeInHierarchy().WithItemID ("eb94bfdb-1140-46f8-971f-e4b41dae13b8").Select(), Throws.InstanceOf<StaleElementException>());
-      Assert.That (() => rootNode.GetNodeInHierarchy ("6866ca48-8957-4f26-ae5f-78a3f6dcc4de").Select(), Throws.InstanceOf<StaleElementException>());
+      Assert.That (
+          () => rootNode.GetNodeInHierarchy().WithDisplayText ("E, ").Select(),
+          Throws.InstanceOf<WebTestException>()
+              .With.Message.EqualTo ("This element has been removed from the DOM."));
+      Assert.That (
+          () => rootNode.GetNodeInHierarchy().WithItemID ("eb94bfdb-1140-46f8-971f-e4b41dae13b8").Select(),
+          Throws.InstanceOf<WebTestException>()
+              .With.Message.EqualTo ("This element has been removed from the DOM."));
+      Assert.That (
+          () => rootNode.GetNodeInHierarchy().WithDisplayTextContains ("A, B").Select(),
+          Throws.InstanceOf<WebTestException>()
+              .With.Message.EqualTo ("This element has been removed from the DOM."));
+      Assert.That (
+          () => rootNode.GetNodeInHierarchy ("6866ca48-8957-4f26-ae5f-78a3f6dcc4de").Select(),
+          Throws.InstanceOf<WebTestException>()
+              .With.Message.EqualTo ("This element has been removed from the DOM."));
     }
 
     [Test]

--- a/Remotion/ObjectBinding/Web.Development.WebTesting.IntegrationTests/BocTreeViewControlObjectTest.cs
+++ b/Remotion/ObjectBinding/Web.Development.WebTesting.IntegrationTests/BocTreeViewControlObjectTest.cs
@@ -295,6 +295,7 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.IntegrationTests
     [Test]
     public void TestSelectNodeInHierarchyOnlyRootNodeExpanded ()
     {
+      const string expectedExceptionMessage = "The element cannot be found: This element has been removed from the DOM. Coypu will normally re-find elements using the original locators in this situation, except if you have captured a snapshot list of all matching elements using FindAllCss() or FindAllXPath()";
       var home = Start();
 
       var bocTreeView = home.TreeViews().GetByLocalID ("Normal");
@@ -305,19 +306,19 @@ namespace Remotion.ObjectBinding.Web.Development.WebTesting.IntegrationTests
       Assert.That (
           () => rootNode.GetNodeInHierarchy().WithDisplayText ("E, ").Select(),
           Throws.InstanceOf<WebTestException>()
-              .With.Message.EqualTo ("This element has been removed from the DOM."));
+              .With.Message.EqualTo (expectedExceptionMessage));
       Assert.That (
           () => rootNode.GetNodeInHierarchy().WithItemID ("eb94bfdb-1140-46f8-971f-e4b41dae13b8").Select(),
           Throws.InstanceOf<WebTestException>()
-              .With.Message.EqualTo ("This element has been removed from the DOM."));
+              .With.Message.EqualTo (expectedExceptionMessage));
       Assert.That (
           () => rootNode.GetNodeInHierarchy().WithDisplayTextContains ("A, B").Select(),
           Throws.InstanceOf<WebTestException>()
-              .With.Message.EqualTo ("This element has been removed from the DOM."));
+              .With.Message.EqualTo (expectedExceptionMessage));
       Assert.That (
           () => rootNode.GetNodeInHierarchy ("6866ca48-8957-4f26-ae5f-78a3f6dcc4de").Select(),
           Throws.InstanceOf<WebTestException>()
-              .With.Message.EqualTo ("This element has been removed from the DOM."));
+              .With.Message.EqualTo (expectedExceptionMessage));
     }
 
     [Test]

--- a/Remotion/Web/Development.WebTesting.ControlObjects/WebTreeViewNodeControlObject.cs
+++ b/Remotion/Web/Development.WebTesting.ControlObjects/WebTreeViewNodeControlObject.cs
@@ -83,7 +83,7 @@ namespace Remotion.Web.Development.WebTesting.ControlObjects
       public WebTreeViewNodeControlObject WithItemID (string itemID)
       {
         var nodeScope = _webTreeViewNode.Scope.FindTagWithAttribute ("ul li", DiagnosticMetadataAttributes.ItemID, itemID);
-        return CreateWebTreeViewNodeControlObject(nodeScope);
+        return CreateWebTreeViewNodeControlObject (nodeScope);
       }
 
       public WebTreeViewNodeControlObject WithIndex (int oneBasedIndex)
@@ -97,13 +97,13 @@ namespace Remotion.Web.Development.WebTesting.ControlObjects
 
         var nodeScope = foundNodes.Single();
 
-        return CreateWebTreeViewNodeControlObject(nodeScope);
+        return CreateWebTreeViewNodeControlObject (nodeScope);
       }
 
       public WebTreeViewNodeControlObject WithDisplayText (string displayText)
       {
         var nodeScope = _webTreeViewNode.Scope.FindTagWithAttribute ("ul li", DiagnosticMetadataAttributes.Content, displayText);
-        return CreateWebTreeViewNodeControlObject(nodeScope);
+        return CreateWebTreeViewNodeControlObject (nodeScope);
       }
 
       public WebTreeViewNodeControlObject WithDisplayTextContains (string containsDisplayText)
@@ -114,7 +114,7 @@ namespace Remotion.Web.Development.WebTesting.ControlObjects
             DiagnosticMetadataAttributes.Content,
             containsDisplayText);
 
-        return CreateWebTreeViewNodeControlObject(nodeScope);
+        return CreateWebTreeViewNodeControlObject (nodeScope);
       }
 
       private WebTreeViewNodeControlObject CreateWebTreeViewNodeControlObject (ElementScope nodeScope)

--- a/Remotion/Web/Development.WebTesting.ControlObjects/WebTreeViewNodeControlObject.cs
+++ b/Remotion/Web/Development.WebTesting.ControlObjects/WebTreeViewNodeControlObject.cs
@@ -16,6 +16,7 @@
 // 
 using System;
 using System.Linq;
+using Coypu;
 using JetBrains.Annotations;
 using Remotion.Utilities;
 using Remotion.Web.Contracts.DiagnosticMetadata;
@@ -82,7 +83,7 @@ namespace Remotion.Web.Development.WebTesting.ControlObjects
       public WebTreeViewNodeControlObject WithItemID (string itemID)
       {
         var nodeScope = _webTreeViewNode.Scope.FindTagWithAttribute ("ul li", DiagnosticMetadataAttributes.ItemID, itemID);
-        return new WebTreeViewNodeControlObject (_webTreeViewNode.Context.CloneForControl (nodeScope));
+        return CreateWebTreeViewNodeControlObject(nodeScope);
       }
 
       public WebTreeViewNodeControlObject WithIndex (int oneBasedIndex)
@@ -96,13 +97,13 @@ namespace Remotion.Web.Development.WebTesting.ControlObjects
 
         var nodeScope = foundNodes.Single();
 
-        return new WebTreeViewNodeControlObject (_webTreeViewNode.Context.CloneForControl (nodeScope));
+        return CreateWebTreeViewNodeControlObject(nodeScope);
       }
 
       public WebTreeViewNodeControlObject WithDisplayText (string displayText)
       {
         var nodeScope = _webTreeViewNode.Scope.FindTagWithAttribute ("ul li", DiagnosticMetadataAttributes.Content, displayText);
-        return new WebTreeViewNodeControlObject (_webTreeViewNode.Context.CloneForControl (nodeScope));
+        return CreateWebTreeViewNodeControlObject(nodeScope);
       }
 
       public WebTreeViewNodeControlObject WithDisplayTextContains (string containsDisplayText)
@@ -112,7 +113,20 @@ namespace Remotion.Web.Development.WebTesting.ControlObjects
             CssComparisonOperator.SubstringMatch,
             DiagnosticMetadataAttributes.Content,
             containsDisplayText);
-        return new WebTreeViewNodeControlObject (_webTreeViewNode.Context.CloneForControl (nodeScope));
+
+        return CreateWebTreeViewNodeControlObject(nodeScope);
+      }
+
+      private WebTreeViewNodeControlObject CreateWebTreeViewNodeControlObject (ElementScope nodeScope)
+      {
+        try
+        {
+          return new WebTreeViewNodeControlObject (_webTreeViewNode.Context.CloneForControl (nodeScope));
+        }
+        catch (StaleElementException)
+        {
+          throw new WebTestException ("This element has been removed from the DOM.");
+        }
       }
     }
 

--- a/Remotion/Web/Development.WebTesting.ControlObjects/WebTreeViewNodeControlObject.cs
+++ b/Remotion/Web/Development.WebTesting.ControlObjects/WebTreeViewNodeControlObject.cs
@@ -123,9 +123,9 @@ namespace Remotion.Web.Development.WebTesting.ControlObjects
         {
           return new WebTreeViewNodeControlObject (_webTreeViewNode.Context.CloneForControl (nodeScope));
         }
-        catch (StaleElementException)
+        catch (StaleElementException ex)
         {
-          throw new WebTestException ("This element has been removed from the DOM.");
+          throw AssertionExceptionUtility.CreateControlMissingException (ex.Message);
         }
       }
     }

--- a/Remotion/Web/Development.WebTesting.IntegrationTests/TreeViewControlObjectTest.cs
+++ b/Remotion/Web/Development.WebTesting.IntegrationTests/TreeViewControlObjectTest.cs
@@ -17,14 +17,12 @@
 using System;
 using Coypu;
 using NUnit.Framework;
-using OpenQA.Selenium;
 using Remotion.Web.Development.WebTesting.CompletionDetectionStrategies;
 using Remotion.Web.Development.WebTesting.ExecutionEngine.CompletionDetectionStrategies;
 using Remotion.Web.Development.WebTesting.ExecutionEngine.PageObjects;
 using Remotion.Web.Development.WebTesting.FluentControlSelection;
 using Remotion.Web.Development.WebTesting.IntegrationTests.Infrastructure;
 using Remotion.Web.Development.WebTesting.IntegrationTests.Infrastructure.TestCaseFactories;
-using Remotion.Web.Development.WebTesting.WebDriver;
 using Remotion.Web.Development.WebTesting.WebFormsControlObjects;
 using Remotion.Web.Development.WebTesting.WebFormsControlObjects.Selectors;
 
@@ -318,8 +316,12 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests
       rootNode.Expand();
 
       rootNode.Scope.ElementFinder.Options.Timeout = TimeSpan.Zero;
-      Assert.That (() => rootNode.GetNodeInHierarchy().WithDisplayText ("Child node 12").Select(), Throws.InstanceOf<StaleElementException>());
-      Assert.That (() => rootNode.GetNodeInHierarchy().WithDisplayTextContains ("11").Select(), Throws.InstanceOf<StaleElementException>());
+      Assert.That (
+          () => rootNode.GetNodeInHierarchy().WithDisplayText ("Child node 12").Select(), Throws.InstanceOf<WebTestException>()
+          .With.Message.EqualTo ("This element has been removed from the DOM."));
+      Assert.That (
+          () => rootNode.GetNodeInHierarchy().WithDisplayTextContains ("11").Select(), Throws.InstanceOf<WebTestException>()
+          .With.Message.EqualTo ("This element has been removed from the DOM."));
     }
 
     [Test]
@@ -379,8 +381,14 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests
 
       treeView.Scope.ElementFinder.Options.Timeout = TimeSpan.Zero;
 
-      Assert.That (() => treeView.GetNodeInHierarchy().WithDisplayText ("Child node 12").Select(), Throws.InstanceOf<ElementNotInteractableException>());
-      Assert.That (() => treeView.GetNodeInHierarchy().WithDisplayTextContains ("11").Select(), Throws.InstanceOf<ElementNotInteractableException>());
+      Assert.That (
+          () => treeView.GetNodeInHierarchy().WithDisplayText ("Child node 12").Select(),
+          Throws.InstanceOf<WebTestException>()
+              .With.Message.EqualTo ("The element cannot be interacted with."));
+      Assert.That (
+          () => treeView.GetNodeInHierarchy().WithDisplayTextContains ("11").Select(),
+          Throws.InstanceOf<WebTestException>()
+              .With.Message.EqualTo ("The element cannot be interacted with."));
     }
 
     [Test]

--- a/Remotion/Web/Development.WebTesting.IntegrationTests/TreeViewControlObjectTest.cs
+++ b/Remotion/Web/Development.WebTesting.IntegrationTests/TreeViewControlObjectTest.cs
@@ -308,6 +308,7 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests
     [Test]
     public void TestSelectNodeInHierarchyOnlyRootNodeExpanded ()
     {
+      const string expectedExceptionMessage = "The element cannot be found: This element has been removed from the DOM. Coypu will normally re-find elements using the original locators in this situation, except if you have captured a snapshot list of all matching elements using FindAllCss() or FindAllXPath()";
       var home = Start();
 
       var treeView = home.TreeViews().GetByLocalID ("MyTreeView");
@@ -318,10 +319,10 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests
       rootNode.Scope.ElementFinder.Options.Timeout = TimeSpan.Zero;
       Assert.That (
           () => rootNode.GetNodeInHierarchy().WithDisplayText ("Child node 12").Select(), Throws.InstanceOf<WebTestException>()
-          .With.Message.EqualTo ("This element has been removed from the DOM."));
+          .With.Message.EqualTo (expectedExceptionMessage));
       Assert.That (
           () => rootNode.GetNodeInHierarchy().WithDisplayTextContains ("11").Select(), Throws.InstanceOf<WebTestException>()
-          .With.Message.EqualTo ("This element has been removed from the DOM."));
+          .With.Message.EqualTo (expectedExceptionMessage));
     }
 
     [Test]
@@ -372,6 +373,7 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests
     [Test]
     public void TestTreeSelectNodeInHierarchyOnlyRootNodeExpanded ()
     {
+      const string expectedExceptionMessage = "The element cannot be found: element not interactable";
       var home = Start();
 
       var treeView = home.TreeViews().GetByLocalID ("MyTreeView");
@@ -384,11 +386,11 @@ namespace Remotion.Web.Development.WebTesting.IntegrationTests
       Assert.That (
           () => treeView.GetNodeInHierarchy().WithDisplayText ("Child node 12").Select(),
           Throws.InstanceOf<WebTestException>()
-              .With.Message.EqualTo ("The element cannot be interacted with."));
+              .With.Message.StartsWith (expectedExceptionMessage));
       Assert.That (
           () => treeView.GetNodeInHierarchy().WithDisplayTextContains ("11").Select(),
           Throws.InstanceOf<WebTestException>()
-              .With.Message.EqualTo ("The element cannot be interacted with."));
+              .With.Message.StartsWith (expectedExceptionMessage));
     }
 
     [Test]

--- a/Remotion/Web/Development.WebTesting.WebFormsControlObjects/TreeViewNodeControlObject.cs
+++ b/Remotion/Web/Development.WebTesting.WebFormsControlObjects/TreeViewNodeControlObject.cs
@@ -122,9 +122,9 @@ namespace Remotion.Web.Development.WebTesting.WebFormsControlObjects
         {
           return new TreeViewNodeControlObject (_treeViewNode.Context.CloneForControl (nodeScope));
         }
-        catch (StaleElementException)
+        catch (StaleElementException ex)
         {
-          throw new WebTestException ("This element has been removed from the DOM.");
+          throw AssertionExceptionUtility.CreateControlMissingException (ex.Message);
         }
       }
     }
@@ -241,9 +241,9 @@ namespace Remotion.Web.Development.WebTesting.WebFormsControlObjects
       {
         ExecuteAction (new ClickAction (this, Scope.FindXPath (nodeClickScopeXpath)), actualCompletionDetector);
       }
-      catch (ElementNotInteractableException)
+      catch (ElementNotInteractableException ex)
       {
-        throw new WebTestException ("The element cannot be interacted with.");
+        throw AssertionExceptionUtility.CreateControlMissingException (ex.Message);
       }
     }
 


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-7186