### PR TITLE
RM-7316: The Firefox CommandTimeout is set to 10 seconds and not affected by the CommandTimeout given in the DriverConfiguration

### DIFF
--- a/Remotion/Web/Development.WebTesting/WebDriver/Factories/Firefox/FirefoxBrowserFactory.cs
+++ b/Remotion/Web/Development.WebTesting/WebDriver/Factories/Firefox/FirefoxBrowserFactory.cs
@@ -48,9 +48,10 @@ namespace Remotion.Web.Development.WebTesting.WebDriver.Factories.Firefox
       ArgumentUtility.CheckNotNull ("driverConfiguration", driverConfiguration);
 
       var sessionConfiguration = CreateSessionConfiguration (driverConfiguration);
+      var commandTimeout = driverConfiguration.CommandTimeout;
 
       var firefoxDriverService = GetFirefoxDriverService();
-      var driver = new FirefoxDriver (firefoxDriverService, _firefoxConfiguration.CreateFirefoxOptions(), TimeSpan.FromSeconds (10));
+      var driver = new FirefoxDriver (firefoxDriverService, _firefoxConfiguration.CreateFirefoxOptions(), commandTimeout);
       var session = new Coypu.BrowserSession (sessionConfiguration, new CustomSeleniumWebDriver (driver, Browser.Firefox));
 
       return new FirefoxBrowserSession (session, _firefoxConfiguration, firefoxDriverService.ProcessId);


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-7316 