### PR TITLE
RM-7393: Add ability to configure AsyncJavascriptTimeout in DriverConfiguration

### DIFF
--- a/Remotion/ObjectBinding/Web.Development.WebTesting.IntegrationTests/App.config
+++ b/Remotion/ObjectBinding/Web.Development.WebTesting.IntegrationTests/App.config
@@ -20,6 +20,7 @@
       searchTimeout="00:00:30"
       verifyWebApplicationStartedTimeout="00:00:10"
       retryInterval="00:00:00.025"
+      asyncJavaScriptTimeout="00:00:10"
       webApplicationRoot="http://localhost:60402/"
       screenshotDirectory=".\WebTestingOutput"
       logsDirectory=".\WebTestingOutput"

--- a/Remotion/ObjectBinding/Web.IntegrationTests/App.config
+++ b/Remotion/ObjectBinding/Web.IntegrationTests/App.config
@@ -19,6 +19,7 @@
       browser="Chrome"
       searchTimeout="00:00:30"
       retryInterval="00:00:00.025"
+      asyncJavaScriptTimeout="00:00:10"
       webApplicationRoot="http://localhost:60402/"
       screenshotDirectory=".\WebTestingOutput"
       logsDirectory=".\WebTestingOutput"

--- a/Remotion/Web/Development.WebTesting.IntegrationTests/App.config
+++ b/Remotion/Web/Development.WebTesting.IntegrationTests/App.config
@@ -22,6 +22,7 @@
       downloadUpdatedTimeout="00:00:10"
       verifyWebApplicationStartedTimeout="00:00:10"
       retryInterval="00:00:00.025"
+      asyncJavaScriptTimeout="00:00:10"
       webApplicationRoot="http://localhost:60401/"
       screenshotDirectory=".\WebTestingOutput"
       logsDirectory=".\WebTestingOutput"

--- a/Remotion/Web/Development.WebTesting.UnitTests/App.config
+++ b/Remotion/Web/Development.WebTesting.UnitTests/App.config
@@ -9,6 +9,7 @@
       commandTimeout="00:13:37"
       searchTimeout="00:00:30"
       retryInterval="00:00:00.025"
+      asyncJavaScriptTimeout="12:34:00"
       webApplicationRoot="http://localhost:60401/"
       screenshotDirectory=".\WebTestingOutput">
     <hosting name="IisExpress" type="IisExpress" port="60401" />

--- a/Remotion/Web/Development.WebTesting.UnitTests/Configuration/WebTestConfigurationSectionTest.cs
+++ b/Remotion/Web/Development.WebTesting.UnitTests/Configuration/WebTestConfigurationSectionTest.cs
@@ -38,6 +38,7 @@ namespace Remotion.Web.Development.WebTesting.UnitTests.Configuration
     screenshotDirectory="".\SomeScreenshotDirectory""
     downloadStartedTimeout=""00:00:13""
     downloadUpdatedTimeout=""00:00:37""
+    asyncJavaScriptTimeout=""00:42:00""
     logsDirectory="".\SomeLogsDirectory""
     closeBrowserWindowsOnSetUpAndTearDown=""false""
     cleanUpUnmatchedDownloadedFiles=""false""
@@ -79,6 +80,7 @@ namespace Remotion.Web.Development.WebTesting.UnitTests.Configuration
       Assert.That (_section.TestSiteLayoutConfiguration.Resources[0].Path, Is.EqualTo (@".\Some\Resource"));
       Assert.That (_section.DownloadStartedTimeout, Is.EqualTo (TimeSpan.FromSeconds (13)));
       Assert.That (_section.DownloadUpdatedTimeout, Is.EqualTo (TimeSpan.FromSeconds (37)));
+      Assert.That (_section.AsyncJavaScriptTimeout, Is.EqualTo (TimeSpan.FromMinutes (42)));
       Assert.That (_section.LogsDirectory, Is.EqualTo (@".\SomeLogsDirectory"));
       Assert.That (_section.CloseBrowserWindowsOnSetUpAndTearDown, Is.EqualTo (false));
       Assert.That (_section.CleanUpUnmatchedDownloadedFiles, Is.EqualTo (false));

--- a/Remotion/Web/Development.WebTesting.UnitTests/WebTestHelperTest.cs
+++ b/Remotion/Web/Development.WebTesting.UnitTests/WebTestHelperTest.cs
@@ -29,9 +29,10 @@ namespace Remotion.Web.Development.WebTesting.UnitTests
     private readonly TimeSpan _configCommandTimeout = TimeSpan.FromSeconds ((13 * 60) + 37);
     private readonly TimeSpan _configSearchTimeout = TimeSpan.FromSeconds (30);
     private readonly TimeSpan _configRetryInterval = TimeSpan.FromMilliseconds (25);
+    private readonly TimeSpan _configAsyncJavaScriptTimeout = TimeSpan.FromHours (12) + TimeSpan.FromMinutes (34);
 
     [Test]
-    public void CreateNewBrowserSession_DefaultValue ()
+    public void CreateNewBrowserSession_ValuesFromConfiguration_WithoutOverride ()
     {
       var webTestHelper = WebTestHelper.CreateFromConfiguration<TestWebTestConfigurationFactory>();
       var browserFactoryStub = webTestHelper.BrowserConfiguration.BrowserFactory;
@@ -42,6 +43,7 @@ namespace Remotion.Web.Development.WebTesting.UnitTests
       Assert.That (driverConfigurationArgument.CommandTimeout, Is.EqualTo (_configCommandTimeout));
       Assert.That (driverConfigurationArgument.SearchTimeout, Is.EqualTo (_configSearchTimeout));
       Assert.That (driverConfigurationArgument.RetryInterval, Is.EqualTo (_configRetryInterval));
+      Assert.That (driverConfigurationArgument.AsyncJavaScriptTimeout, Is.EqualTo (_configAsyncJavaScriptTimeout));
     }
 
     [Test]
@@ -57,6 +59,7 @@ namespace Remotion.Web.Development.WebTesting.UnitTests
       Assert.That (driverConfigurationArgument.CommandTimeout, Is.EqualTo (TimeSpan.FromMinutes (5)));
       Assert.That (driverConfigurationArgument.SearchTimeout, Is.EqualTo (_configSearchTimeout));
       Assert.That (driverConfigurationArgument.RetryInterval, Is.EqualTo (_configRetryInterval));
+      Assert.That (driverConfigurationArgument.AsyncJavaScriptTimeout, Is.EqualTo (_configAsyncJavaScriptTimeout));
     }
 
     [Test]
@@ -72,6 +75,7 @@ namespace Remotion.Web.Development.WebTesting.UnitTests
       Assert.That (driverConfigurationArgument.CommandTimeout, Is.EqualTo (_configCommandTimeout));
       Assert.That (driverConfigurationArgument.SearchTimeout, Is.EqualTo (TimeSpan.FromMinutes (5)));
       Assert.That (driverConfigurationArgument.RetryInterval, Is.EqualTo (_configRetryInterval));
+      Assert.That (driverConfigurationArgument.AsyncJavaScriptTimeout, Is.EqualTo (_configAsyncJavaScriptTimeout));
     }
 
     [Test]
@@ -87,6 +91,23 @@ namespace Remotion.Web.Development.WebTesting.UnitTests
       Assert.That (driverConfigurationArgument.CommandTimeout, Is.EqualTo (_configCommandTimeout));
       Assert.That (driverConfigurationArgument.SearchTimeout, Is.EqualTo (_configSearchTimeout));
       Assert.That (driverConfigurationArgument.RetryInterval, Is.EqualTo (TimeSpan.FromMinutes (5)));
+      Assert.That (driverConfigurationArgument.AsyncJavaScriptTimeout, Is.EqualTo (_configAsyncJavaScriptTimeout));
+    }
+
+    [Test]
+    public void CreateNewBrowserSession_AsyncJavaScriptTimeoutOverride ()
+    {
+      var webTestHelper = WebTestHelper.CreateFromConfiguration<TestWebTestConfigurationFactory>();
+      var configurationOverride = new DriverConfigurationOverride { AsyncJavaScriptTimeout = TimeSpan.FromMinutes (5) };
+      var browserFactoryStub = webTestHelper.BrowserConfiguration.BrowserFactory;
+
+      webTestHelper.CreateNewBrowserSession (false, configurationOverride);
+
+      var driverConfigurationArgument = GetBrowserFactoryStubCreateBrowserArgument (browserFactoryStub);
+      Assert.That (driverConfigurationArgument.CommandTimeout, Is.EqualTo (_configCommandTimeout));
+      Assert.That (driverConfigurationArgument.SearchTimeout, Is.EqualTo (_configSearchTimeout));
+      Assert.That (driverConfigurationArgument.RetryInterval, Is.EqualTo (_configRetryInterval));
+      Assert.That (driverConfigurationArgument.AsyncJavaScriptTimeout, Is.EqualTo (TimeSpan.FromMinutes (5)));
     }
 
     private DriverConfiguration GetBrowserFactoryStubCreateBrowserArgument (IBrowserFactory browserFactoryStub)

--- a/Remotion/Web/Development.WebTesting/Configuration/DriverConfiguration.cs
+++ b/Remotion/Web/Development.WebTesting/Configuration/DriverConfiguration.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using OpenQA.Selenium;
 
 namespace Remotion.Web.Development.WebTesting.Configuration
 {
@@ -39,11 +40,17 @@ namespace Remotion.Web.Development.WebTesting.Configuration
     /// </summary>
     public TimeSpan RetryInterval { get; }
 
-    public DriverConfiguration (TimeSpan commandTimeout, TimeSpan searchTimeout, TimeSpan retryInterval)
+    /// <summary>
+    /// Returns the timeout that Selenium uses to determine how long to wait for asynchronous callbacks when using <see cref="IJavaScriptExecutor.ExecuteAsyncScript" />.
+    /// </summary>
+    public TimeSpan AsyncJavaScriptTimeout { get; }
+
+    public DriverConfiguration (TimeSpan commandTimeout, TimeSpan searchTimeout, TimeSpan retryInterval, TimeSpan asyncJavaScriptTimeout)
     {
       CommandTimeout = commandTimeout;
       SearchTimeout = searchTimeout;
       RetryInterval = retryInterval;
+      AsyncJavaScriptTimeout = asyncJavaScriptTimeout;
     }
   }
 }

--- a/Remotion/Web/Development.WebTesting/Configuration/WebTestConfigurationSection.cs
+++ b/Remotion/Web/Development.WebTesting/Configuration/WebTestConfigurationSection.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Configuration;
 using System.IO;
+using OpenQA.Selenium;
 using Remotion.Utilities;
 using Remotion.Web.Development.WebTesting.DownloadInfrastructure;
 
@@ -33,6 +34,7 @@ namespace Remotion.Web.Development.WebTesting.Configuration
     private readonly ConfigurationProperty _browserProperty;
     private readonly ConfigurationProperty _searchTimeoutProperty;
     private readonly ConfigurationProperty _commandTimeoutProperty;
+    private readonly ConfigurationProperty _asyncJavaScriptTimeoutProperty;
     private readonly ConfigurationProperty _downloadStartedTimeoutProperty;
     private readonly ConfigurationProperty _downloadUpdatedTimeoutProperty;
     private readonly ConfigurationProperty _verifyWebApplicationStartedTimeoutProperty;
@@ -71,6 +73,7 @@ namespace Remotion.Web.Development.WebTesting.Configuration
           ConfigurationPropertyOptions.IsRequired);
       _searchTimeoutProperty = new ConfigurationProperty ("searchTimeout", typeof (TimeSpan), null, ConfigurationPropertyOptions.IsRequired);
       _commandTimeoutProperty = new ConfigurationProperty ("commandTimeout", typeof (TimeSpan), TimeSpan.FromMinutes (1));
+      _asyncJavaScriptTimeoutProperty = new ConfigurationProperty ("asyncJavaScriptTimeout", typeof (TimeSpan), TimeSpan.FromSeconds (10));
       _downloadStartedTimeoutProperty = new ConfigurationProperty ("downloadStartedTimeout", typeof (TimeSpan), TimeSpan.FromSeconds (10));
       _downloadUpdatedTimeoutProperty = new ConfigurationProperty ("downloadUpdatedTimeout", typeof (TimeSpan), TimeSpan.FromSeconds (10));
       _verifyWebApplicationStartedTimeoutProperty = new ConfigurationProperty ("verifyWebApplicationStartedTimeout", typeof (TimeSpan), TimeSpan.FromMinutes (1));
@@ -98,6 +101,7 @@ namespace Remotion.Web.Development.WebTesting.Configuration
                         _browserProperty,
                         _searchTimeoutProperty,
                         _commandTimeoutProperty,
+                        _asyncJavaScriptTimeoutProperty,
                         _downloadStartedTimeoutProperty,
                         _downloadUpdatedTimeoutProperty,
                         _verifyWebApplicationStartedTimeoutProperty,
@@ -150,6 +154,14 @@ namespace Remotion.Web.Development.WebTesting.Configuration
     public TimeSpan CommandTimeout
     {
       get { return (TimeSpan) this [_commandTimeoutProperty]; }
+    }
+
+    /// <summary>
+    /// Specifies how long Selenium should maximally wait for asynchronous callbacks after calling <see cref="IJavaScriptExecutor.ExecuteAsyncScript" /> before failing.
+    /// </summary>
+    public TimeSpan AsyncJavaScriptTimeout
+    {
+      get { return (TimeSpan) this [_asyncJavaScriptTimeoutProperty]; }
     }
 
     /// <summary>

--- a/Remotion/Web/Development.WebTesting/DriverConfigurationOverride.cs
+++ b/Remotion/Web/Development.WebTesting/DriverConfigurationOverride.cs
@@ -15,6 +15,7 @@
 // along with re-motion; if not, see http://www.gnu.org/licenses.
 // 
 using System;
+using OpenQA.Selenium;
 using Remotion.Web.Development.WebTesting.Configuration;
 
 namespace Remotion.Web.Development.WebTesting
@@ -39,6 +40,11 @@ namespace Remotion.Web.Development.WebTesting
     /// after the given <see cref="RetryInterval" /> until the <see cref="SearchTimeout" /> has been reached.
     /// </summary>
     public TimeSpan? RetryInterval { get; set; }
+
+    /// <summary>
+    /// Returns the timeout that Selenium uses to determine how long to wait for asynchronous callbacks when using <see cref="IJavaScriptExecutor.ExecuteAsyncScript" />.
+    /// </summary>
+    public TimeSpan? AsyncJavaScriptTimeout { get; set; }
 
     public DriverConfigurationOverride ()
     {

--- a/Remotion/Web/Development.WebTesting/Schemas/WebTestingConfiguration.xsd
+++ b/Remotion/Web/Development.WebTesting/Schemas/WebTestingConfiguration.xsd
@@ -41,6 +41,7 @@
       <xs:attribute name="browser" type="c:BrowserType" use="required" />
       <xs:attribute name="searchTimeout" type="xs:time" use="required" />
       <xs:attribute name="commandTimeout" type="xs:time" default="00:01:00" />
+      <xs:attribute name="asyncJavaScriptTimeout" type="xs:time" default="00:00:10" />
       <xs:attribute name="downloadStartedTimeout" type="xs:time" default="00:00:10" />
       <xs:attribute name="downloadUpdatedTimeout" type="xs:time" default="00:00:10" />
       <xs:attribute name="verifyWebApplicationStartedTimeout" type="xs:time" default="00:01:00" />

--- a/Remotion/Web/Development.WebTesting/WebDriver/Factories/Chrome/ChromeBrowserFactory.cs
+++ b/Remotion/Web/Development.WebTesting/WebDriver/Factories/Chrome/ChromeBrowserFactory.cs
@@ -56,6 +56,7 @@ namespace Remotion.Web.Development.WebTesting.WebDriver.Factories.Chrome
       var commandTimeout = configuration.CommandTimeout;
 
       var driver = CreateChromeDriver (out var driverProcessID, commandTimeout);
+      driver.Manage().Timeouts().AsynchronousJavaScript = configuration.AsyncJavaScriptTimeout;
 
       var session = new Coypu.BrowserSession (sessionConfiguration, new CustomSeleniumWebDriver (driver, Browser.Chrome));
 

--- a/Remotion/Web/Development.WebTesting/WebDriver/Factories/Edge/EdgeBrowserFactory.cs
+++ b/Remotion/Web/Development.WebTesting/WebDriver/Factories/Edge/EdgeBrowserFactory.cs
@@ -56,6 +56,7 @@ namespace Remotion.Web.Development.WebTesting.WebDriver.Factories.Edge
       var commandTimeout = configuration.CommandTimeout;
 
       var driver = CreateEdgeDriver (out var driverProcessID, commandTimeout);
+      driver.Manage().Timeouts().AsynchronousJavaScript = configuration.AsyncJavaScriptTimeout;
 
       var session = new Coypu.BrowserSession (sessionConfiguration, new CustomSeleniumWebDriver (driver, Browser.Edge));
 

--- a/Remotion/Web/Development.WebTesting/WebDriver/Factories/Firefox/FirefoxBrowserFactory.cs
+++ b/Remotion/Web/Development.WebTesting/WebDriver/Factories/Firefox/FirefoxBrowserFactory.cs
@@ -52,6 +52,7 @@ namespace Remotion.Web.Development.WebTesting.WebDriver.Factories.Firefox
 
       var firefoxDriverService = GetFirefoxDriverService();
       var driver = new FirefoxDriver (firefoxDriverService, _firefoxConfiguration.CreateFirefoxOptions(), commandTimeout);
+      driver.Manage().Timeouts().AsynchronousJavaScript = driverConfiguration.AsyncJavaScriptTimeout;
       var session = new Coypu.BrowserSession (sessionConfiguration, new CustomSeleniumWebDriver (driver, Browser.Firefox));
 
       return new FirefoxBrowserSession (session, _firefoxConfiguration, firefoxDriverService.ProcessId);

--- a/Remotion/Web/Development.WebTesting/WebDriver/Factories/InternetExplorer/InternetExplorerBrowserFactory.cs
+++ b/Remotion/Web/Development.WebTesting/WebDriver/Factories/InternetExplorer/InternetExplorerBrowserFactory.cs
@@ -50,6 +50,7 @@ namespace Remotion.Web.Development.WebTesting.WebDriver.Factories.InternetExplor
 
       int driverProcessId;
       var driver = CreateInternetExplorerDriver (out driverProcessId, commandTimeout);
+      driver.Manage().Timeouts().AsynchronousJavaScript = configuration.AsyncJavaScriptTimeout;
 
       var session = new Coypu.BrowserSession (sessionConfiguration, new CustomSeleniumWebDriver (driver, Browser.InternetExplorer));
 

--- a/Remotion/Web/Development.WebTesting/WebTestConfigurationFactory.cs
+++ b/Remotion/Web/Development.WebTesting/WebTestConfigurationFactory.cs
@@ -99,7 +99,8 @@ namespace Remotion.Web.Development.WebTesting
       return new DriverConfiguration (
           configSettings.CommandTimeout,
           configSettings.SearchTimeout,
-          configSettings.RetryInterval);
+          configSettings.RetryInterval,
+          configSettings.AsyncJavaScriptTimeout);
     }
 
     /// <summary>

--- a/Remotion/Web/Development.WebTesting/WebTestHelper.cs
+++ b/Remotion/Web/Development.WebTesting/WebTestHelper.cs
@@ -358,7 +358,8 @@ namespace Remotion.Web.Development.WebTesting
       return new DriverConfiguration (
           configurationOverride.CommandTimeout ?? configuration.CommandTimeout,
           configurationOverride.SearchTimeout ?? configuration.SearchTimeout,
-          configurationOverride.RetryInterval ?? configuration.RetryInterval);
+          configurationOverride.RetryInterval ?? configuration.RetryInterval,
+          configurationOverride.AsyncJavaScriptTimeout ?? configuration.AsyncJavaScriptTimeout);
     }
 	  
     /// <summary>

--- a/Remotion/Web/IntegrationTests/App.config
+++ b/Remotion/Web/IntegrationTests/App.config
@@ -21,6 +21,7 @@
       downloadStartedTimeout="00:00:10"
       downloadUpdatedTimeout="00:00:10"
       retryInterval="00:00:00.025"
+      asyncJavaScriptTimeout="00:00:10"
       webApplicationRoot="http://localhost:60401/"
       screenshotDirectory=".\WebTestingOutput"
       logsDirectory=".\WebTestingOutput"


### PR DESCRIPTION
### Jira Issue
https://re-motion.atlassian.net/browse/RM-7393

### Breaking Changes
DriverConfiguration now requires an additional `TimeSpan` parameter in its constructor for the `asyncJavaScriptTimeout`.

### How to test
Automated tests have been provided. In addition, to test if this actually does something in real scenario you can run `AccessibilityIFrameSupportTest.TestInjectSourceToIFrames` inside Internet Explorer (Yes, IE, sorry). It should fail before this PR and succeed with these changes.

### Checklist

- [x] I have adapted schema files if I made changes to XML Config Files.
- [x] All new files have license headers.
- [x] All new public classes, methods and properties have XML documentation and JetBrains annotations.
- [x] I have identified all breaking changes and marked them appropriately.
- [x] I have followed the style guide to the best of my ability.
- [x] If I added new projects to the solution, I also added them to the corresponding `projects.props` file.

