### PR TITLE
RM-7405: Update Build Script to v2.0.0-alpha022

### DIFF
--- a/Build-Remotion.cmd
+++ b/Build-Remotion.cmd
@@ -11,7 +11,7 @@ if not exist %msbuild% set msbuild="%program-path%\Microsoft Visual Studio\2017\
 set log-dir=build\BuildOutput\log
 set nuget-bin=build\BuildOutput\temp\nuget-bin
 set nuget=%nuget-bin%\nuget.exe
-set nuget-download=powershell.exe -NoProfile -Command "& {(New-Object System.Net.WebClient).DownloadFile('https://www.nuget.org/nuget.exe','%nuget%')}"
+set nuget-download=powershell.exe -NoProfile -Command "& {(New-Object System.Net.WebClient).DownloadFile('https://dist.nuget.org/win-x86-commandline/latest/nuget.exe','%nuget%')}"
 
 if not exist remotion.snk goto nosnk
 

--- a/Build/Shared.Extensions.targets
+++ b/Build/Shared.Extensions.targets
@@ -51,55 +51,6 @@
     <Message Text="Configured build properties: $(BuildProperties)" />
   </Target>
 
-  <Target Name="After_CreateTestConfigurations" AfterTargets="CreateTestConfigurations">
-    <ItemGroup>
-      <AllDatabaseSystems Remove="@(AllDatabaseSystems)" />
-
-      <AllDatabaseSystems Include="SqlServerDefault" Condition="'%(DatabaseSystemsList.Identity)' == 'SqlServerDefault'"/>
-      <AllDatabaseSystems Include="SqlServer2012" Condition="'%(DatabaseSystemsList.Identity)' == 'SqlServer2012'"/>
-      <AllDatabaseSystems Include="SqlServer2014" Condition="'%(DatabaseSystemsList.Identity)' == 'SqlServer2014'"/>
-      <AllDatabaseSystems Include="SqlServer2016" Condition="'%(DatabaseSystemsList.Identity)' == 'SqlServer2016'"/>
-      <AllDatabaseSystems Include="SqlServer2017" Condition="'%(DatabaseSystemsList.Identity)' == 'SqlServer2017'"/>
-    </ItemGroup>
-
-    <ItemGroup>
-      <AllBrowsers Remove="@(AllBrowsers)"/>
-
-      <AllBrowsers Include="Chrome" Condition="'%(BrowsersList.Identity)' == 'Chrome'" />
-      <AllBrowsers Include="Edge" Condition="'%(BrowsersList.Identity)' == 'Edge'" />
-      <AllBrowsers Include="Firefox" Condition="'%(BrowsersList.Identity)' == 'Firefox'" />
-      <AllBrowsers Include="InternetExplorer" Condition="'%(BrowsersList.Identity)' == 'InternetExplorer'" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="After_BuildTestOutputFilesCrossProduct" AfterTargets="BuildTestOutputFilesCrossProduct">
-    <ItemGroup>
-      <_testOutputFilesWithWebTests Include="@(TestOutputFiles)" Condition="'%(IsWebTest)' == 'True'"/>
-
-      <_testOutputFilesWithInternetExplorer Include="@(_testOutputFiles)" Condition="'%(Browser)' == 'InternetExplorer'"/>
-      <_testOutputFilesWithFirefox Include="@(_testOutputFiles)" Condition="'%(Browser)' == 'Firefox'"/>
-      <_testOutputFilesWithChrome Include="@(_testOutputFiles)" Condition="'%(Browser)' == 'Chrome'"/>
-      <_testOutputFilesWithEdge Include="@(_testOutputFiles)" Condition="'%(Browser)' == 'Edge'"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'@(_testOutputFilesWithInternetExplorer->Count())' &gt; '@(_testOutputFilesWithWebTests->Count())'">
-      <_testOutputFiles Remove="@(_testOutputFiles)" Condition="'%(Browser)' == 'InternetExplorer' And ('%(Platform)' != 'x86' Or '$(ConfigurationID)' != 'Release')"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'@(_testOutputFilesWithFirefox->Count())' &gt; '@(_testOutputFilesWithWebTests->Count())'">
-      <_testOutputFiles Remove="@(_testOutputFiles)" Condition="'%(Browser)' == 'Firefox' And ('%(Platform)' != 'x64' Or '$(ConfigurationID)' != 'Debug')"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'@(_testOutputFilesWithChrome->Count())' &gt; '@(_testOutputFilesWithWebTests->Count())'">
-      <_testOutputFiles Remove="@(_testOutputFiles)" Condition="'%(Browser)' == 'Chrome' And ('%(Platform)' != 'x64' Or '$(ConfigurationID)' != 'Release')"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'@(_testOutputFilesWithEdge->Count())' &gt; '@(_testOutputFilesWithWebTests->Count())'">
-      <_testOutputFiles Remove="@(_testOutputFiles)" Condition="'%(Browser)' == 'Edge' And ('%(Platform)' != 'x86' Or '$(ConfigurationID)' != 'Debug')"/>
-    </ItemGroup>
-
-  </Target>
-
   <Target Name="Before_ProcessForDependDBInternal" BeforeTargets="ProcessForDependDBInternal">
     <PropertyGroup>
       <!-- Set TargetFramework for resolving the dependencies to the highest common framework name -->

--- a/Build/Shared.Server.Extensions.targets
+++ b/Build/Shared.Server.Extensions.targets
@@ -22,8 +22,10 @@
   <Target Name="ArtifactBuild_Configuration">
     <PropertyGroup>
       <Platforms>x64</Platforms>
-      <DatabaseSystems>SqlServer2012</DatabaseSystems>
-      <Browsers></Browsers>
+      <DatabaseSystems>SqlServer2012+NoDB</DatabaseSystems>
+      <Browsers>NoBrowser</Browsers>
+      <ExecutionRuntimes>Win_NET48</ExecutionRuntimes>
+      <TargetRuntimes>NET48</TargetRuntimes>
       <SkipDocumentation>True</SkipDocumentation>
     </PropertyGroup>
   </Target>
@@ -31,8 +33,10 @@
   <Target Name="CIProductionBuild_Configuration">
     <PropertyGroup>
       <Platforms>x64</Platforms>
-      <DatabaseSystems>SqlServer2012</DatabaseSystems>
-      <Browsers>Chrome</Browsers>
+      <DatabaseSystems>SqlServer2012+NoDB</DatabaseSystems>
+      <Browsers>Chrome+NoBrowser</Browsers>
+      <ExecutionRuntimes>Win_NET48+EnforcedLocalMachine</ExecutionRuntimes>
+      <TargetRuntimes>NET48</TargetRuntimes>
       <SkipDocumentation>True</SkipDocumentation>
     </PropertyGroup>
   </Target>
@@ -40,8 +44,10 @@
   <Target Name="FullBuildReduced_Configuration">
     <PropertyGroup>
       <Platforms>x64</Platforms>
-      <DatabaseSystems>SqlServer2012</DatabaseSystems>
-      <Browsers>Chrome+InternetExplorer</Browsers>
+      <DatabaseSystems>SqlServer2012+NoDB</DatabaseSystems>
+      <Browsers>Chrome+InternetExplorer+Firefox+Edge+NoBrowser</Browsers>
+      <ExecutionRuntimes>Win_NET48+EnforcedLocalMachine</ExecutionRuntimes>
+      <TargetRuntimes>NET48</TargetRuntimes>
       <TestCategoriesToExclude></TestCategoriesToExclude>
     </PropertyGroup>
   </Target>

--- a/Build/TestingSetupForWebTest.targets
+++ b/Build/TestingSetupForWebTest.targets
@@ -29,11 +29,14 @@
     <Error Text="The property 'Platform' is not set." Condition="'$(Platform)' == ''" />
     <Error Text="The property 'AppConfigFile' is not set." Condition="'$(AppConfigFile)' == ''" />
     <Error Text="The property 'Browser' is not set." Condition="'$(Browser)' == ''" />
+    <Error Text="The property 'HostTestSitesInDocker' is not set." Condition="'$(HostTestSitesInDocker)' == ''" />
 
     <PropertyGroup>
-      <_dockerEnabled>False</_dockerEnabled>
-      <_dockerEnabled Condition="'$(DisableDocker)' == 'False'">True</_dockerEnabled>
-      <_dockerImageName>mcr.microsoft.com/dotnet/framework/aspnet:4.6.2</_dockerImageName>
+      <_dockerImageTag Condition="'$(Browser)' == 'InternetExplorer'">4.8</_dockerImageTag>
+      <_dockerImageTag Condition="'$(Browser)' == 'Chrome'">4.8</_dockerImageTag>
+      <_dockerImageTag Condition="'$(Browser)' == 'Edge'">4.8</_dockerImageTag>
+      <_dockerImageTag Condition="'$(Browser)' == 'Firefox'">4.7.2</_dockerImageTag>
+      <_dockerImageName>mcr.microsoft.com/dotnet/framework/aspnet:$(_dockerImageTag)</_dockerImageName>
       <!-- Hostname cannot be longer than 63 characters-->
       <_dockerHostName>RemotionWebTestContainer</_dockerHostName>
       <_dockerPortNumber>60402</_dockerPortNumber>
@@ -42,12 +45,13 @@
       <_dockerVerifyWebApplicationStartedTimeout>00:01:00</_dockerVerifyWebApplicationStartedTimeout>
     </PropertyGroup>
 
+    <Error Text="No known browser could be identified." Condition="'$(_dockerImageTag)' == ''" />
     <Message Text="Selected Browser: '$(Browser)'" />
     <Message Text="The property 'ChromeVersionArchive' is set to '$(ChromeVersionArchive)'." />
     <Message Text="The property 'EdgeVersionArchive' is set to '$(EdgeVersionArchive)'." />
     <Message Text="The property 'FirefoxVersionArchive' is set to '$(FirefoxVersionArchive)'." />
-    <Message Text="Docker enabled: '$(_dockerEnabled)'" />
-    <Message Text="Using Docker image '$(_dockerImageName)' to host the test site." Condition="'$(_dockerEnabled)' == 'True'" />
+    <Message Text="Docker enabled: '$(HostTestSitesInDocker)'" />
+    <Message Text="Using Docker image '$(_dockerImageName)' to host the test site." Condition="'$(HostTestSitesInDocker)' == 'True'" />
 
     <MSBuild.ExtensionPack.Xml.XmlFile
         TaskAction="ReadAttribute"
@@ -120,7 +124,7 @@
       </_appConfigAttributes>
     </ItemGroup>
 
-    <ItemGroup Condition="$(_dockerEnabled)">
+    <ItemGroup Condition="'$(HostTestSitesInDocker)' == 'True'">
       <_appConfigAttributes Include="/configuration/rwt:remotion.webTesting">
         <Key>webApplicationRoot</Key>
         <Value>$(_dockerWebApplicationRoot)</Value>

--- a/Remotion/Build/Customizations/Projects.props
+++ b/Remotion/Build/Customizations/Projects.props
@@ -2,16 +2,51 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <TestExecutionRuntime>net-4.6.1</TestExecutionRuntime>
+    <TestSetupBuildFileForDatabase>$(SolutionDirectory)Build\TestingSetupForDatabase.targets</TestSetupBuildFileForDatabase>
+    <TestSetupBuildFileForWebTest>$(SolutionDirectory)Build\TestingSetupForWebTest.targets</TestSetupBuildFileForWebTest>
   </PropertyGroup>
 
   <PropertyGroup>
-    <TestingSetupBuildFileForDatabase>$(SolutionDirectory)Build\TestingSetupForDatabase.targets</TestingSetupBuildFileForDatabase>
-    <TestingSetupBuildFileForWebTest>$(SolutionDirectory)Build\TestingSetupForWebTest.targets</TestingSetupBuildFileForWebTest>
+    <WebtestingTestConfiguration Condition="'$(WebtestingTestConfiguration)' == ''">
+      Chrome           + NET462 + Debug   + x86 + NoDB + EnforcedLocalMachine;<!-- Upgrade to NET48 once it is supported -->
+      Firefox          + NET462 + Release + x64 + NoDB + EnforcedLocalMachine;<!-- Upgrade to NET472 once all agents support it -->
+      InternetExplorer + NET462 + Release + x64 + NoDB + EnforcedLocalMachine;<!-- Upgrade to NET48 once it is supported -->
+      Edge             + NET462 + Release + x64 + NoDB + EnforcedLocalMachine;<!-- Upgrade to NET48 once it is supported -->
+    </WebtestingTestConfiguration>
+    <DatabaseTestConfiguration Condition="'$(DatabaseTestConfiguration)' == ''">
+      Win_NET48  + NET48  + NoBrowser + SqlServer2012 + Debug   + x86;
+      Win_NET48  + NET48  + NoBrowser + SqlServer2012 + Release + x86;
+      Win_NET48  + NET48  + NoBrowser + SqlServer2012 + Debug   + x64;
+      Win_NET48  + NET48  + NoBrowser + SqlServer2012 + Release + x64;
+
+      <!-- Local-->
+      LocalMachine  + NET48  + NoBrowser + SqlServerDefault + Debug + x86;
+
+      <!-- Exercise compatibility between installed .NET version, target framework and SQL Server -->
+      Win_NET48  + NET472 + NoBrowser + SqlServer2017 + Release + x64;
+      Win_NET48  + NET472 + NoBrowser + SqlServer2014 + Release + x64;<!-- Change to SqlServer2019 once it exists -->
+      Win_NET472 + NET472 + NoBrowser + SqlServer2016 + Release + x64;
+      Win_NET472 + NET472 + NoBrowser + SqlServer2014 + Release + x64;
+    </DatabaseTestConfiguration>
+    <NormalTestConfiguration Condition="'$(NormalTestConfiguration)' == ''">
+      Win_NET48  + NET48  + NoBrowser + NoDB + Debug   + x86;
+      Win_NET48  + NET48  + NoBrowser + NoDB + Release + x86;
+      Win_NET48  + NET48  + NoBrowser + NoDB + Debug   + x64;
+      Win_NET48  + NET48  + NoBrowser + NoDB + Release + x64;
+
+      <!-- Local-->
+      LocalMachine  + NET48  + NoBrowser + SqlServerDefault + Debug + x86;
+
+      <!-- Compatibility Mode -->
+      Win_NET48  + NET472 + NoBrowser + NoDB + Release + x64;
+      Win_NET472 + NET472 + NoBrowser + NoDB + Release + x64;
+    </NormalTestConfiguration>
   </PropertyGroup>
 
   <ItemGroup>
-    <UnitTestProjectFiles Include="$(SolutionDirectory)\SharedSource\UnitTests\SharedSource.UnitTests.csproj"/>
+    <UnitTestProjectFiles Include="$(SolutionDirectory)\SharedSource\UnitTests\SharedSource.UnitTests.csproj">
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
+    </UnitTestProjectFiles>
 
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Core\Core\Core.Core.csproj">
       <CreateNuGetPackageWithSymbolServerSupport>True</CreateNuGetPackageWithSymbolServerSupport>
@@ -33,34 +68,34 @@
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Core\Tools\Core.Tools.csproj"/>
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Core\Xml\Core.Xml.csproj"/>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Core\UnitTests\Core.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Core\Collections.Caching.UnitTests\Core.Collections.Caching.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Core\Collections.DataStore.UnitTests\Core.Collections.DataStore.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Core\ExtensibleEnums.UnitTests\Core.ExtensibleEnums.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Core\Extensions.UnitTests\Core.Extensions.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Core\Reflection.UnitTests\Core.Reflection.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Core\Reflection.CodeGeneration.UnitTests\Core.Reflection.CodeGeneration.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Core\Reflection.CodeGeneration.TypePipe.UnitTests\Core.Reflection.CodeGeneration.TypePipe.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Core\Tools.UnitTests\Core.Tools.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Core\Xml.UnitTests\Core.Xml.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
 
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Development\CodeDom\Development.CodeDom.csproj"/>
@@ -69,8 +104,12 @@
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Development\Mixins\Development.Mixins.csproj"/>
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Development\Web\Development.Web.csproj"/>
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Development\Sandboxing.NUnit2\Development.Sandboxing.NUnit2.csproj"/>
-    <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Development\UnitTests\Development.UnitTests.csproj"/>
-    <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Development\Sandboxing.NUnit2.UnitTests\Development.Sandboxing.NUnit2.UnitTests.csproj"/>
+    <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Development\UnitTests\Development.UnitTests.csproj">
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
+    </UnitTestProjectFiles>
+    <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Development\Sandboxing.NUnit2.UnitTests\Development.Sandboxing.NUnit2.UnitTests.csproj">
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
+    </UnitTestProjectFiles>
 
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Mixins\Core\Mixins.Core.csproj">
       <!-- When enabling the package for NuGet.org, the nuspec file must be TemplateSharedForNuGetOrg.nuspec to act as trigger for removing the -rtm tag on the NuGet version. -->
@@ -78,37 +117,39 @@
     </ReleaseProjectFiles>
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Mixins\MixerTools\Mixins.MixerTools.csproj"/>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Mixins\UnitTests\Mixins.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
 
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Globalization\Core\Globalization.Core.csproj"/>
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Globalization\ExtensibleEnums\Globalization.ExtensibleEnums.csproj"/>
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Globalization\Mixins\Globalization.Mixins.csproj"/>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Globalization\UnitTests\Globalization.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Globalization\ExtensibleEnums.UnitTests\Globalization.ExtensibleEnums.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Globalization\Mixins.UnitTests\Globalization.Mixins.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
 
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Validation\Core\Validation.Core.csproj"/>
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Validation\Globalization\Validation.Globalization.csproj"/>
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Validation\Mixins\Validation.Mixins.csproj"/>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Validation\UnitTests\Validation.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
-    <IntegrationTestProjectFiles Include="$(SolutionDirectory)\Remotion\Validation\IntegrationTests\Validation.IntegrationTests.csproj"/>
+    <IntegrationTestProjectFiles Include="$(SolutionDirectory)\Remotion\Validation\IntegrationTests\Validation.IntegrationTests.csproj">
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
+    </IntegrationTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Validation\Globalization.UnitTests\Validation.Globalization.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Validation\Mixins.UnitTests\Validation.Mixins.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <IntegrationTestProjectFiles Include="$(SolutionDirectory)\Remotion\Validation\Mixins.IntegrationTests\Validation.Mixins.IntegrationTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </IntegrationTestProjectFiles>
 
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Data\Core\Data.Core.csproj"/>
@@ -119,39 +160,35 @@
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Data\DomainObjects.UberProfIntegration\Data.DomainObjects.UberProfIntegration.csproj"/>
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Data\DomainObjects.Validation\Data.DomainObjects.Validation.csproj"/>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Data\DomainObjects.UnitTests\Data.DomainObjects.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
-      <IsDatabaseTest>True</IsDatabaseTest>
-      <TestingSetupBuildFile>$(TestingSetupBuildFileForDatabase)</TestingSetupBuildFile>
+      <TestConfiguration>$(DatabaseTestConfiguration)</TestConfiguration>
+      <TestSetupBuildFile>$(TestSetupBuildFileForDatabase)</TestSetupBuildFile>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Data\DomainObjects.ObjectBinding.UnitTests\Data.DomainObjects.ObjectBinding.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Data\DomainObjects.ObjectBinding.IntegrationTests\Data.DomainObjects.ObjectBinding.IntegrationTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
-      <IsDatabaseTest>True</IsDatabaseTest>
-      <TestingSetupBuildFile>$(TestingSetupBuildFileForDatabase)</TestingSetupBuildFile>
+      <TestConfiguration>$(DatabaseTestConfiguration)</TestConfiguration>
+      <TestSetupBuildFile>$(TestSetupBuildFileForDatabase)</TestSetupBuildFile>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Data\DomainObjects.RdbmsTools.UnitTests\Data.DomainObjects.RdbmsTools.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Data\DomainObjects.Security.UnitTests\Data.DomainObjects.Security.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Data\DomainObjects.UberProfIntegration.UnitTests\Data.DomainObjects.UberProfIntegration.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
-      <IsDatabaseTest>True</IsDatabaseTest>
-      <TestingSetupBuildFile>$(TestingSetupBuildFileForDatabase)</TestingSetupBuildFile>
+      <TestConfiguration>$(DatabaseTestConfiguration)</TestConfiguration>
+      <TestSetupBuildFile>$(TestSetupBuildFileForDatabase)</TestSetupBuildFile>
     </UnitTestProjectFiles>
     <IntegrationTestProjectFiles Include="$(SolutionDirectory)\Remotion\Data\DomainObjects.Web.IntegrationTests\Data.DomainObjects.Web.IntegrationTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
-      <IsDatabaseTest>True</IsDatabaseTest>
-      <TestingSetupBuildFile>$(TestingSetupBuildFileForDatabase)</TestingSetupBuildFile>
+      <TestConfiguration>$(DatabaseTestConfiguration)</TestConfiguration>
+      <TestSetupBuildFile>$(TestSetupBuildFileForDatabase)</TestSetupBuildFile>
     </IntegrationTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Data\DomainObjects.Validation.UnitTests\Data.DomainObjects.Validation.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <IntegrationTestProjectFiles Include="$(SolutionDirectory)\Remotion\Data\DomainObjects.Validation.IntegrationTests\Data.DomainObjects.Validation.IntegrationTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </IntegrationTestProjectFiles>
 
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\ObjectBinding\Core\ObjectBinding.Core.csproj"/>
@@ -163,36 +200,34 @@
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\ObjectBinding\Web.Preview\ObjectBinding.Web.Preview.csproj"/>
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\ObjectBinding\Web.Validation\ObjectBinding.Web.Validation.csproj"/>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\ObjectBinding\UnitTests\ObjectBinding.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\ObjectBinding\Security.UnitTests\ObjectBinding.Security.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\ObjectBinding\Validation.UnitTests\ObjectBinding.Validation.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\ObjectBinding\Web.UnitTests\ObjectBinding.Web.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\ObjectBinding\Web.Validation.UnitTests\ObjectBinding.Web.Validation.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <IntegrationTestProjectFiles Include="$(SolutionDirectory)\Remotion\ObjectBinding\Web.Development.WebTesting.IntegrationTests\ObjectBinding.Web.Development.WebTesting.IntegrationTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
-      <IsWebTest>True</IsWebTest>
-      <TestingSetupBuildFile>$(TestingSetupBuildFileForWebTest)</TestingSetupBuildFile>
+      <TestConfiguration>$(WebtestingTestConfiguration)</TestConfiguration>
+      <TestSetupBuildFile>$(TestSetupBuildFileForWebTest)</TestSetupBuildFile>
     </IntegrationTestProjectFiles>
     <IntegrationTestProjectFiles Include="$(SolutionDirectory)\Remotion\ObjectBinding\Web.IntegrationTests\ObjectBinding.Web.IntegrationTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
-      <IsWebTest>True</IsWebTest>
-      <TestingSetupBuildFile>$(TestingSetupBuildFileForWebTest)</TestingSetupBuildFile>
+      <TestConfiguration>$(WebtestingTestConfiguration)</TestConfiguration>
+      <TestSetupBuildFile>$(TestSetupBuildFileForWebTest)</TestSetupBuildFile>
     </IntegrationTestProjectFiles>
 
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Security\Core\Security.Core.csproj"/>
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Security\Metadata.Extractor\Security.Metadata.Extractor.csproj"/>
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Security\MSBuild.Tasks\Security.MSBuild.Tasks.csproj"/>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Security\UnitTests\Security.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
 
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Web\Contracts.DiagnosticMetadata\Web.Contracts.DiagnosticMetadata.csproj"/>
@@ -207,27 +242,25 @@
     <!--<ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Web\Development.WebTesting.IntegrationTest.Infrastructure\Web.Development.WebTesting.IntegrationTests.Infrastructure.csproj"/>
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Web\Development.WebTesting.TestSite.Infrastructure\Web.Development.WebTesting.TestSite.Infrastructure.csproj"/>-->
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Web\Development.WebTesting.UnitTests\Web.Development.WebTesting.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Web\UnitTests\Web.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
 
     <IntegrationTestProjectFiles Include="$(SolutionDirectory)\Remotion\Web\Development.WebTesting.IntegrationTests\Web.Development.WebTesting.IntegrationTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
-      <IsWebTest>True</IsWebTest>
-      <TestingSetupBuildFile>$(TestingSetupBuildFileForWebTest)</TestingSetupBuildFile>
+      <TestConfiguration>$(WebtestingTestConfiguration)</TestConfiguration>
+      <TestSetupBuildFile>$(TestSetupBuildFileForWebTest)</TestSetupBuildFile>
     </IntegrationTestProjectFiles>
 
     <IntegrationTestProjectFiles Include="$(SolutionDirectory)\Remotion\Web\IntegrationTests\Web.IntegrationTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
-      <IsWebTest>True</IsWebTest>
-      <TestingSetupBuildFile>$(TestingSetupBuildFileForWebTest)</TestingSetupBuildFile>
+      <TestConfiguration>$(WebtestingTestConfiguration)</TestConfiguration>
+      <TestSetupBuildFile>$(TestSetupBuildFileForWebTest)</TestSetupBuildFile>
     </IntegrationTestProjectFiles>
 
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Scripting\Core\Scripting.Core.csproj"/>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\Remotion\Scripting\UnitTests\Scripting.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
+      <TestConfiguration>$(NormalTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
 
     <ReleaseProjectFiles Include="$(SolutionDirectory)\Remotion\Integration\Domain\Integration.Domain.csproj"/>

--- a/Remotion/Build/Remotion.Local.build
+++ b/Remotion/Build/Remotion.Local.build
@@ -35,26 +35,33 @@
     <SkipSourceLinks>True</SkipSourceLinks>
     <SkipNuGet>True</SkipNuGet>
     <SkipDependDB>True</SkipDependDB>
-    <DisableDocker>True</DisableDocker>
+    <HostTestSitesInDocker>False</HostTestSitesInDocker>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DockerImageDotNetFrameworkRuntime4_7 Condition="'$(DockerImageDotNetFrameworkRuntime4_7)' == ''">Unavailable</DockerImageDotNetFrameworkRuntime4_7>
+    <DockerImageDotNetFrameworkRuntime4_8 Condition="'$(DockerImageDotNetFrameworkRuntime4_8)' == ''">Unavailable</DockerImageDotNetFrameworkRuntime4_8>
   </PropertyGroup>
   
   <Target Name="TestBuild_Configuration">
     <PropertyGroup>
       <Platforms>x86</Platforms>
-      <DatabaseSystems>SqlServerDefault</DatabaseSystems>
-      <Browsers></Browsers>
+      <DatabaseSystems>SqlServerDefault+NoDB</DatabaseSystems>
+      <Browsers>NoBrowser</Browsers>
       <TestCategoriesToExclude></TestCategoriesToExclude>
       <SkipTests>False</SkipTests>
+      <ExecutionRuntimes>LocalMachine</ExecutionRuntimes>
+      <TargetRuntimes>NET48</TargetRuntimes>
     </PropertyGroup>
   </Target>
   
   <Target Name="FullBuild_Configuration">
     <PropertyGroup>
-      <!-- Skip x86 -->
       <Platforms>x64</Platforms>
-      <DatabaseSystems>SqlServerDefault</DatabaseSystems>
-      <!-- Skip Internet Explorer -->
+      <DatabaseSystems>SqlServerDefault+NoDB</DatabaseSystems>
       <Browsers>Chrome</Browsers>
+      <ExecutionRuntimes>LocalMachine</ExecutionRuntimes>
+      <TargetRuntimes>NET48</TargetRuntimes>
       <TestCategoriesToExclude></TestCategoriesToExclude>
       <SkipTests>False</SkipTests>
       <SkipNuGet>False</SkipNuGet>

--- a/Remotion/Build/Remotion.Server.build
+++ b/Remotion/Build/Remotion.Server.build
@@ -50,8 +50,10 @@
   <Target Name="TestBuild_Configuration">
     <PropertyGroup>
       <Platforms>x86</Platforms>
-      <DatabaseSystems>SqlServer2012</DatabaseSystems>
-      <Browsers>Chrome</Browsers>
+      <DatabaseSystems>SqlServer2012+NoDB</DatabaseSystems>
+      <Browsers>Chrome+NoBrowser</Browsers>
+      <ExecutionRuntimes>Win_NET48+EnforcedLocalMachine</ExecutionRuntimes>
+      <TargetRuntimes>NET48+NET462</TargetRuntimes><!-- Remove NET462 once NET48 is installed on build agents -->
       <TestCategoriesToExclude></TestCategoriesToExclude>
     </PropertyGroup>
   </Target>
@@ -59,8 +61,10 @@
   <Target Name="FullBuild_Configuration">
     <PropertyGroup>
       <Platforms>x86+x64</Platforms>
-      <DatabaseSystems>SqlServer2017+SqlServer2012+SqlServer2014+SqlServer2016</DatabaseSystems>
-      <Browsers>Chrome+InternetExplorer+Firefox+Edge</Browsers>
+      <DatabaseSystems>SqlServer2012+SqlServer2014+SqlServer2016+SqlServer2017+NoDB</DatabaseSystems>
+      <Browsers>Chrome+InternetExplorer+Firefox+Edge+NoBrowser</Browsers>
+      <ExecutionRuntimes>Win_NET472+Win_NET48+EnforcedLocalMachine</ExecutionRuntimes>
+      <TargetRuntimes>NET48+NET472+NET462</TargetRuntimes><!-- Remove NET462 once NET48 is installed on build agents -->
       <TestCategoriesToExclude></TestCategoriesToExclude>
     </PropertyGroup>
   </Target>

--- a/Remotion/Build/Remotion.build
+++ b/Remotion/Build/Remotion.build
@@ -25,12 +25,25 @@
     <ExtensionTasksPath>$(MSBuildExtensionPackPath)</ExtensionTasksPath>
     <DependDBBuildProcessorToolPath Condition="'$(NuGetToolPath)' == ''">$(PackagesDirectory)DependDB.BuildProcessor.2.0.0\tools\</DependDBBuildProcessorToolPath>
     <DependDBNuGetPreProcessorToolPath Condition="'$(NuGetToolPath)' == ''">$(PackagesDirectory)DependDB.BuildProcessor.NuGetPreProcessor.2.0.0\tools\</DependDBNuGetPreProcessorToolPath>
-    <NUnitToolPath Condition="'$(NUnitToolPath)' == ''">$(PackagesDirectory)NUnit.Runners.2.7.1\tools\</NUnitToolPath>
+    <NUnitToolPath Condition="'$(NUnitToolPath)' == ''">$(PackagesDirectory)NUnit.ConsoleRunner.3.11.1\tools\</NUnitToolPath>
     <NuGetToolPath Condition="'$(NuGetToolPath)' == ''">$(PackagesDirectory)NuGet.CommandLine.3.5.0\tools\</NuGetToolPath>
     <NuGetForMSBuildPath Condition="'$(NuGetForMSBuildPath)' == ''">$(PackagesDirectory)NuGet.for.MSBuild.1.4.3\build\</NuGetForMSBuildPath>
     <RemotionBuildTasksPath Condition="'$(RemotionBuildTasksPath)' == ''">$(PackagesDirectory)Remotion.BuildTools.MSBuildTasks.1.0.6862.28795\tools\</RemotionBuildTasksPath>
-    <RemotionBuildScriptPath Condition="'$(RemotionBuildScriptPath)' == ''">$(PackagesDirectory)Remotion.BuildScript.2.0.0-alpha021\BuildTargets\</RemotionBuildScriptPath>
+    <RemotionBuildScriptPath Condition="'$(RemotionBuildScriptPath)' == ''">$(PackagesDirectory)Remotion.BuildScript.2.0.0-alpha022\BuildTargets\</RemotionBuildScriptPath>
   </PropertyGroup>
+
+  <ItemGroup>
+    <NUnitExtensionsPaths Include="$(PackagesDirectory)NUnit.Extension.NUnitV2Driver.3.8.0\"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <SupportedBrowsers Include="Chrome;InternetExplorer;Firefox;Edge"/>
+    <SupportedPlatforms Include="x86;x64"/>
+    <SupportedDatabaseSystems Include="SqlServerDefault;SqlServer2012;SqlServer2014;SqlServer2016;SqlServer2017;SqlServer2019"/>
+    <SupportedExecutionRuntimes Include="Win_NET472=$(DockerImageDotNetFrameworkRuntime4_7);Win_NET48=$(DockerImageDotNetFrameworkRuntime4_8)"/>
+    <SupportedTargetRuntimes Include="NET48;NET472;NET462;"/><!-- Remove NET462 once NET48 is installed on build agents -->
+    <SupportedConfigurationIDs Include="Debug;Release"/>
+  </ItemGroup>
 
   <Import Project="$(RemotionBuildScriptPath)*.targets" />
   <Import Project="$(MSBuildExtensionPackPath)MSBuild.ExtensionPack.tasks" />
@@ -47,7 +60,7 @@
     <SkipSourceLinks>False</SkipSourceLinks>
     <SkipNuGet>False</SkipNuGet>
     <SkipDependDB>False</SkipDependDB>
-    <DisableDocker>False</DisableDocker>
+    <HostTestSitesInDocker>True</HostTestSitesInDocker>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -84,8 +97,10 @@
           Platforms=$(Platforms);
           DatabaseSystems=$(DatabaseSystems);
           Browsers=$(Browsers);
+          TargetRuntimes=$(TargetRuntimes);
+          ExecutionRuntimes=$(ExecutionRuntimes);
           TestCategoriesToExclude=$(TestCategoriesToExclude);
-          DisableDocker=$(DisableDocker);
+          HostTestSitesInDocker=$(HostTestSitesInDocker);
       </BuildProperties>
     </PropertyGroup>
 
@@ -139,16 +154,16 @@
   <Target Name="BuildAll" DependsOnTargets="CleanFolders;PrepareBuildProperties;PrepareBuildTargets;">
 
     <ItemGroup>
-      <_allConfigurations Remove="@(_allConfigurations)" />
+      <_configurationIDs Remove="@(_configurationIDs)" />
       <!-- By listing the debug-build first, the documentation will be generated based on the debug output. -->
-      <_allConfigurations Include="Debug" />
-      <_allConfigurations Include="Release" />
+      <_configurationIDs Include="Debug" />
+      <_configurationIDs Include="Release" />
     </ItemGroup>
 
     <MSBuild Projects="$(MSBuildProjectFile)"
              BuildInParallel="false"
              Targets="$(FullBuildTargets)"
-             Properties="ConfigurationID=%(_allConfigurations.Identity);$(BuildProperties);"/>
+             Properties="ConfigurationID=%(_configurationIDs.Identity);$(BuildProperties);"/>
   </Target>
   
   <Target Name="TestBuildDebugOnly" DependsOnTargets="CleanFolders;PrepareBuildProperties;PrepareBuildTargets;">

--- a/Remotion/Build/packages.config
+++ b/Remotion/Build/packages.config
@@ -3,9 +3,10 @@
   <package id="DependDB.BuildProcessor" version="2.0.0" targetFramework="net461" developmentDependency="true" />
   <package id="DependDB.BuildProcessor.NuGetPreProcessor" version="2.0.0" targetFramework="net461" />
   <package id="MSBuild.Extension.Pack" version="1.5.0" targetFramework="net461" developmentDependency="true" />
-  <package id="NuGet.CommandLine" version="2.8.0" targetFramework="net461" developmentDependency="true" />
+  <package id="NuGet.CommandLine" version="3.5.0" targetFramework="net461" developmentDependency="true" />
   <package id="NuGet.for.MSBuild" version="1.4.3" targetFramework="net461" developmentDependency="true" />
-  <package id="NUnit.Runners" version="2.7.1" targetFramework="net461" developmentDependency="true" />
-  <package id="Remotion.BuildScript" version="2.0.0-alpha021" targetFramework="net461" developmentDependency="true" />
+  <package id="NUnit.ConsoleRunner" version="3.11.1" targetFramework="net461" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.8.0" targetFramework="net461" />
+  <package id="Remotion.BuildScript" version="2.0.0-alpha022" targetFramework="net461" developmentDependency="true" />
   <package id="Remotion.BuildTools.MSBuildTasks" version="1.0.6862.28795" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/SecurityManager/Build/Customizations/Projects.props
+++ b/SecurityManager/Build/Customizations/Projects.props
@@ -2,11 +2,25 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <TestExecutionRuntime>net-4.6.1</TestExecutionRuntime>
+    <TestSetupBuildFileForDatabase>$(SolutionDirectory)Build\TestingSetupForDatabase.targets</TestSetupBuildFileForDatabase>
   </PropertyGroup>
 
   <PropertyGroup>
-    <TestingSetupBuildFile>$(SolutionDirectory)Build\TestingSetupForDatabase.targets</TestingSetupBuildFile>
+    <DatabaseTestConfiguration Condition="'$(DatabaseTestConfiguration)' == ''">
+      Win_NET48 + NET48 + NoBrowser + SqlServer2012 + Debug   + x86;
+      Win_NET48 + NET48 + NoBrowser + SqlServer2012 + Release + x86;
+      Win_NET48 + NET48 + NoBrowser + SqlServer2012 + Debug   + x64;
+      Win_NET48 + NET48 + NoBrowser + SqlServer2012 + Release + x64;
+
+      <!-- Local-->
+      LocalMachine + NET48 + NoBrowser + SqlServerDefault + Debug + x86;
+
+      <!-- Exercise compatibility between installed .NET version, target framework and SQL Server -->
+      Win_NET48  + NET472 + NoBrowser + SqlServer2017 + Release + x64;
+      Win_NET48  + NET472 + NoBrowser + SqlServer2014 + Release + x64;<!-- Change to SqlServer2019 once it exists -->
+      Win_NET472 + NET472 + NoBrowser + SqlServer2016 + Release + x64;
+      Win_NET472 + NET472 + NoBrowser + SqlServer2014 + Release + x64;
+    </DatabaseTestConfiguration>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,9 +32,8 @@
     </ReleaseProjectFiles>
     <ReleaseProjectFiles Include="$(SolutionDirectory)\SecurityManager\Metadata.Importer\SecurityManager.Metadata.Importer.csproj"/>
     <UnitTestProjectFiles Include="$(SolutionDirectory)\SecurityManager\Core.UnitTests\SecurityManager.Core.UnitTests.csproj">
-      <ExecutionRuntime>$(TestExecutionRuntime)</ExecutionRuntime>
-      <IsDatabaseTest>True</IsDatabaseTest>
-      <TestingSetupBuildFile>$(TestingSetupBuildFile)</TestingSetupBuildFile>
+      <TestSetupBuildFile>$(TestSetupBuildFileForDatabase)</TestSetupBuildFile>
+      <TestConfiguration>$(DatabaseTestConfiguration)</TestConfiguration>
     </UnitTestProjectFiles>
   </ItemGroup>
 </Project>

--- a/SecurityManager/Build/Remotion.Local.build
+++ b/SecurityManager/Build/Remotion.Local.build
@@ -35,26 +35,33 @@
     <SkipSourceLinks>True</SkipSourceLinks>
     <SkipNuGet>True</SkipNuGet>
     <SkipDependDB>True</SkipDependDB>
-    <DisableDocker>True</DisableDocker>
+    <HostTestSitesInDocker>False</HostTestSitesInDocker>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DockerImageDotNetFrameworkRuntime4_7 Condition="'$(DockerImageDotNetFrameworkRuntime4_7)' == ''">Unavailable</DockerImageDotNetFrameworkRuntime4_7>
+    <DockerImageDotNetFrameworkRuntime4_8 Condition="'$(DockerImageDotNetFrameworkRuntime4_8)' == ''">Unavailable</DockerImageDotNetFrameworkRuntime4_8>
   </PropertyGroup>
   
   <Target Name="TestBuild_Configuration">
     <PropertyGroup>
       <Platforms>x86</Platforms>
       <DatabaseSystems>SqlServerDefault</DatabaseSystems>
-      <Browsers></Browsers>
-      <TestCategoriesToExclude></TestCategoriesToExclude>
+      <Browsers>NoBrowser</Browsers>
       <SkipTests>False</SkipTests>
+      <TestCategoriesToExclude></TestCategoriesToExclude>
+      <ExecutionRuntimes>LocalMachine</ExecutionRuntimes>
+      <TargetRuntimes>NET48</TargetRuntimes>
     </PropertyGroup>
   </Target>
   
   <Target Name="FullBuild_Configuration">
     <PropertyGroup>
-      <!-- Skip x86 -->
       <Platforms>x64</Platforms>
       <DatabaseSystems>SqlServerDefault</DatabaseSystems>
-      <!-- Skip Internet Explorer -->
       <Browsers>Chrome</Browsers>
+      <ExecutionRuntimes>LocalMachine</ExecutionRuntimes>
+      <TargetRuntimes>NET48</TargetRuntimes>
       <TestCategoriesToExclude></TestCategoriesToExclude>
       <SkipTests>False</SkipTests>
       <SkipNuGet>False</SkipNuGet>

--- a/SecurityManager/Build/Remotion.Server.build
+++ b/SecurityManager/Build/Remotion.Server.build
@@ -50,8 +50,10 @@
   <Target Name="TestBuild_Configuration">
     <PropertyGroup>
       <Platforms>x86</Platforms>
-      <DatabaseSystems>SqlServer2012</DatabaseSystems>
-      <Browsers>Chrome</Browsers>
+      <DatabaseSystems>SqlServer2012+NoDB</DatabaseSystems>
+      <Browsers>Chrome+NoBrowser</Browsers>
+      <ExecutionRuntimes>Win_NET48</ExecutionRuntimes>
+      <TargetRuntimes>NET48</TargetRuntimes>
       <TestCategoriesToExclude></TestCategoriesToExclude>
     </PropertyGroup>
   </Target>
@@ -59,8 +61,10 @@
   <Target Name="FullBuild_Configuration">
     <PropertyGroup>
       <Platforms>x86+x64</Platforms>
-      <DatabaseSystems>SqlServer2017+SqlServer2012+SqlServer2014+SqlServer2016</DatabaseSystems>
-      <Browsers>Chrome+InternetExplorer+Firefox+Edge</Browsers>
+      <ExecutionRuntimes>Win_NET472+Win_NET48</ExecutionRuntimes>
+      <DatabaseSystems>SqlServer2012+SqlServer2014+SqlServer2016+SqlServer2017</DatabaseSystems>
+      <Browsers>NoBrowser</Browsers>
+      <TargetRuntimes>NET48+NET472</TargetRuntimes>
       <TestCategoriesToExclude></TestCategoriesToExclude>
     </PropertyGroup>
   </Target>

--- a/SecurityManager/Build/Remotion.build
+++ b/SecurityManager/Build/Remotion.build
@@ -25,12 +25,25 @@
     <ExtensionTasksPath>$(MSBuildExtensionPackPath)</ExtensionTasksPath>
     <DependDBBuildProcessorToolPath Condition="'$(NuGetToolPath)' == ''">$(PackagesDirectory)DependDB.BuildProcessor.2.0.0\tools\</DependDBBuildProcessorToolPath>
     <DependDBNuGetPreProcessorToolPath Condition="'$(NuGetToolPath)' == ''">$(PackagesDirectory)DependDB.BuildProcessor.NuGetPreProcessor.2.0.0\tools\</DependDBNuGetPreProcessorToolPath>
-    <NUnitToolPath Condition="'$(NUnitToolPath)' == ''">$(PackagesDirectory)NUnit.Runners.2.7.1\tools\</NUnitToolPath>
+    <NUnitToolPath Condition="'$(NUnitToolPath)' == ''">$(PackagesDirectory)NUnit.ConsoleRunner.3.11.1\tools\</NUnitToolPath>
     <NuGetToolPath Condition="'$(NuGetToolPath)' == ''">$(PackagesDirectory)NuGet.CommandLine.3.5.0\tools\</NuGetToolPath>
     <NuGetForMSBuildPath Condition="'$(NuGetForMSBuildPath)' == ''">$(PackagesDirectory)NuGet.for.MSBuild.1.4.3\build\</NuGetForMSBuildPath>
     <RemotionBuildTasksPath Condition="'$(RemotionBuildTasksPath)' == ''">$(PackagesDirectory)Remotion.BuildTools.MSBuildTasks.1.0.6862.28795\tools\</RemotionBuildTasksPath>
-    <RemotionBuildScriptPath Condition="'$(RemotionBuildScriptPath)' == ''">$(PackagesDirectory)Remotion.BuildScript.2.0.0-alpha021\BuildTargets\</RemotionBuildScriptPath>
+    <RemotionBuildScriptPath Condition="'$(RemotionBuildScriptPath)' == ''">$(PackagesDirectory)Remotion.BuildScript.2.0.0-alpha022\BuildTargets\</RemotionBuildScriptPath>
   </PropertyGroup>
+
+  <ItemGroup>
+    <NUnitExtensionsPaths Include="$(PackagesDirectory)NUnit.Extension.NUnitV2Driver.3.8.0\"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <SupportedBrowsers Include="Chrome;InternetExplorer;Firefox;Edge"/>
+    <SupportedPlatforms Include="x86;x64"/>
+    <SupportedDatabaseSystems Include="SqlServerDefault;SqlServer2012;SqlServer2014;SqlServer2016;SqlServer2017;SqlServer2019"/>
+    <SupportedExecutionRuntimes Include="Win_NET472=$(DockerImageDotNetFrameworkRuntime4_7);Win_NET48=$(DockerImageDotNetFrameworkRuntime4_8)"/>
+    <SupportedTargetRuntimes Include="NET48;NET472;"/>
+    <SupportedConfigurationIDs Include="Debug;Release"/>
+  </ItemGroup>
 
   <Import Project="$(RemotionBuildScriptPath)*.targets" />
   <Import Project="$(MSBuildExtensionPackPath)MSBuild.ExtensionPack.tasks" />
@@ -47,7 +60,7 @@
     <SkipSourceLinks>False</SkipSourceLinks>
     <SkipNuGet>False</SkipNuGet>
     <SkipDependDB>False</SkipDependDB>
-    <DisableDocker>False</DisableDocker>
+    <HostTestSitesInDocker>True</HostTestSitesInDocker>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -83,9 +96,11 @@
           VcsUrlRequiresWindowsCredentials=$(VcsUrlRequiresWindowsCredentials);
           Platforms=$(Platforms);
           DatabaseSystems=$(DatabaseSystems);
+          ExecutionRuntimes=$(ExecutionRuntimes);
           Browsers=$(Browsers);
+          TargetRuntimes=$(TargetRuntimes);
           TestCategoriesToExclude=$(TestCategoriesToExclude);
-          DisableDocker=$(DisableDocker);
+          HostTestSitesInDocker=$(HostTestSitesInDocker);
       </BuildProperties>
     </PropertyGroup>
 
@@ -139,16 +154,16 @@
   <Target Name="BuildAll" DependsOnTargets="CleanFolders;PrepareBuildProperties;PrepareBuildTargets;">
 
     <ItemGroup>
-      <_allConfigurations Remove="@(_allConfigurations)" />
+      <_configurationIDs Remove="@(_configurationIDs)" />
       <!-- By listing the debug-build first, the documentation will be generated based on the debug output. -->
-      <_allConfigurations Include="Debug" />
-      <_allConfigurations Include="Release" />
+      <_configurationIDs Include="Debug" />
+      <_configurationIDs Include="Release" />
     </ItemGroup>
 
     <MSBuild Projects="$(MSBuildProjectFile)"
              BuildInParallel="false"
              Targets="$(FullBuildTargets)"
-             Properties="ConfigurationID=%(_allConfigurations.Identity);$(BuildProperties);"/>
+             Properties="ConfigurationID=%(_configurationIDs.Identity);$(BuildProperties);"/>
   </Target>
   
   <Target Name="TestBuildDebugOnly" DependsOnTargets="CleanFolders;PrepareBuildProperties;PrepareBuildTargets;">

--- a/SecurityManager/Build/packages.config
+++ b/SecurityManager/Build/packages.config
@@ -3,9 +3,10 @@
   <package id="DependDB.BuildProcessor" version="2.0.0" targetFramework="net461" developmentDependency="true" />
   <package id="DependDB.BuildProcessor.NuGetPreProcessor" version="2.0.0" targetFramework="net461" />
   <package id="MSBuild.Extension.Pack" version="1.5.0" targetFramework="net461" developmentDependency="true" />
-  <package id="NuGet.CommandLine" version="2.8.0" targetFramework="net461" developmentDependency="true" />
+  <package id="NuGet.CommandLine" version="3.5.0" targetFramework="net461" developmentDependency="true" />
   <package id="NuGet.for.MSBuild" version="1.4.3" targetFramework="net461" developmentDependency="true" />
-  <package id="NUnit.Runners" version="2.7.1" targetFramework="net461" developmentDependency="true" />
-  <package id="Remotion.BuildScript" version="2.0.0-alpha021" targetFramework="net461" developmentDependency="true" />
+  <package id="NUnit.ConsoleRunner" version="3.11.1" targetFramework="net461" />
+  <package id="NUnit.Extension.NUnitV2Driver" version="3.8.0" targetFramework="net461" />
+  <package id="Remotion.BuildScript" version="2.0.0-alpha022" targetFramework="net461" developmentDependency="true" />
   <package id="Remotion.BuildTools.MSBuildTasks" version="1.0.6862.28795" targetFramework="net461" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
### Jira Issue
https://re-motion.atlassian.net/browse/RM-7405

### Breaking Changes
None

### How to test
If all configurations were adapted correctly, there should be no difference between running builds and this branch and on develelop.

Due to a bug in NUnit 2.7.1, however, all tests marked as `[Explicit]` are not skipped and are being run instead. This bug is gone in NUnit 3.12.0.

### Checklist

- [x] I have adapted schema files if I made changes to XML Config Files.
- [x] All new files have license headers.
- [x] All new public classes, methods and properties have XML documentation and JetBrains annotations.
- [x] I have identified all breaking changes and marked them appropriately.
- [x] I have followed the style guide to the best of my ability.
- [x] If I added new projects to the solution, I also added them to the corresponding `projects.props` file.

