### PR TITLE
RM-7435: Marked StringUtility.ConcatWithSeparator overload obsolete

### DIFF
--- a/Remotion/Core/Core/Utilities/StringUtility.cs
+++ b/Remotion/Core/Core/Utilities/StringUtility.cs
@@ -275,9 +275,12 @@ namespace Remotion.Utilities
 
     public static string ConcatWithSeparator (IList list, string separator)
     {
+#pragma warning disable 618
       return ConcatWithSeparator (list, separator, null, null);
+#pragma warning restore 618
     }
 
+    [Obsolete ("Use ConcatWithSeperator (IList, string) instead. Parameter 'format' is no longer used.")]
     public static string ConcatWithSeparator (IList list, string separator, string format, IFormatProvider formatProvider)
     {
       if (list == null)
@@ -343,7 +346,9 @@ namespace Remotion.Utilities
       string format = null;
       if (elementType == typeof (float) || elementType == typeof (double))
         format = "R";
+#pragma warning disable 618
       return ConcatWithSeparator ((IList) value, ",", format, formatProvider);
+#pragma warning restore 618
     }
 
     private static string FormatScalarValue (object value, IFormatProvider formatProvider)

--- a/Remotion/Core/Core/Utilities/StringUtility.cs
+++ b/Remotion/Core/Core/Utilities/StringUtility.cs
@@ -280,7 +280,7 @@ namespace Remotion.Utilities
 #pragma warning restore 618
     }
 
-    [Obsolete ("Use ConcatWithSeperator (IList, string) instead. Parameter 'format' is no longer used.")]
+    [Obsolete ("Use ConcatWithSeperator (IList, string) instead. Parameter 'format' is no longer used. (Version 1.21.8)")]
     public static string ConcatWithSeparator (IList list, string separator, string format, IFormatProvider formatProvider)
     {
       if (list == null)


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-7435