### PR TITLE
RM-3427: Use DateTime.UtcNow instead of DateTime.Now for function timeouts

### DIFF
--- a/Remotion/Web/Core/ExecutionEngine/WxeFunctionStateManager.cs
+++ b/Remotion/Web/Core/ExecutionEngine/WxeFunctionStateManager.cs
@@ -53,7 +53,7 @@ namespace Remotion.Web.ExecutionEngine
         get { return Item3; }
       }
 
-      [Obsolete ("Use LastAccessUtc instead. (Version 1.21.8)", false)]
+      [Obsolete ("Use LastAccessUtc instead. LastAccess now also returns the value as UTC. (Version 1.21.8)", false)]
       public DateTime LastAccess
       {
         get { return Item3; }

--- a/Remotion/Web/Core/ExecutionEngine/WxeFunctionStateManager.cs
+++ b/Remotion/Web/Core/ExecutionEngine/WxeFunctionStateManager.cs
@@ -134,7 +134,7 @@ namespace Remotion.Web.ExecutionEngine
       {
         _functionStates.Add (
             functionState.FunctionToken,
-            new WxeFunctionStateMetaData (functionState.FunctionToken, functionState.Lifetime, DateTime.Now));
+            new WxeFunctionStateMetaData (functionState.FunctionToken, functionState.Lifetime, DateTime.UtcNow));
         _session.Add (GetSessionKeyForFunctionState (functionState.FunctionToken), functionState);
       }
     }
@@ -210,7 +210,7 @@ namespace Remotion.Web.ExecutionEngine
       {
         WxeFunctionStateMetaData functionStateMetaData;
         if (_functionStates.TryGetValue (functionToken, out functionStateMetaData))
-          return functionStateMetaData.LastAccess.AddMinutes (functionStateMetaData.Lifetime) < DateTime.Now;
+          return functionStateMetaData.LastAccess.AddMinutes (functionStateMetaData.Lifetime) < DateTime.UtcNow;
 
         return true;
       }
@@ -236,7 +236,7 @@ namespace Remotion.Web.ExecutionEngine
 
         s_log.Debug (string.Format ("Refreshing WxeFunctionState {0}.", functionToken));
         WxeFunctionStateMetaData old = _functionStates[functionToken];
-        _functionStates[functionToken] = new WxeFunctionStateMetaData (old.FunctionToken, old.Lifetime, DateTime.Now);
+        _functionStates[functionToken] = new WxeFunctionStateMetaData (old.FunctionToken, old.Lifetime, DateTime.UtcNow);
       }
     }
 

--- a/Remotion/Web/Core/ExecutionEngine/WxeFunctionStateManager.cs
+++ b/Remotion/Web/Core/ExecutionEngine/WxeFunctionStateManager.cs
@@ -33,8 +33,8 @@ namespace Remotion.Web.ExecutionEngine
     [Serializable]
     public class WxeFunctionStateMetaData : Tuple<string, int, DateTime>
     {
-      public WxeFunctionStateMetaData (string functionToken, int lifetime, DateTime lastAccess)
-          : base (functionToken, lifetime, lastAccess)
+      public WxeFunctionStateMetaData (string functionToken, int lifetime, DateTime lastAccessUtc)
+          : base (functionToken, lifetime, lastAccessUtc)
       {
       }
 
@@ -48,7 +48,7 @@ namespace Remotion.Web.ExecutionEngine
         get { return Item2; }
       }
 
-      public DateTime LastAccess
+      public DateTime LastAccessUtc
       {
         get { return Item3; }
       }
@@ -210,20 +210,20 @@ namespace Remotion.Web.ExecutionEngine
       {
         WxeFunctionStateMetaData functionStateMetaData;
         if (_functionStates.TryGetValue (functionToken, out functionStateMetaData))
-          return functionStateMetaData.LastAccess.AddMinutes (functionStateMetaData.Lifetime) < DateTime.UtcNow;
+          return functionStateMetaData.LastAccessUtc.AddMinutes (functionStateMetaData.Lifetime) < DateTime.UtcNow;
 
         return true;
       }
     }
 
-    public DateTime GetLastAccess (string functionToken)
+    public DateTime GetLastAccessUtc (string functionToken)
     {
       ArgumentUtility.CheckNotNullOrEmpty ("functionToken", functionToken);
       lock (_lockObject)
       {
         CheckFunctionTokenExists (functionToken);
 
-        return _functionStates[functionToken].LastAccess;
+        return _functionStates[functionToken].LastAccessUtc;
       }
     }
 

--- a/Remotion/Web/Core/ExecutionEngine/WxeFunctionStateManager.cs
+++ b/Remotion/Web/Core/ExecutionEngine/WxeFunctionStateManager.cs
@@ -52,6 +52,12 @@ namespace Remotion.Web.ExecutionEngine
       {
         get { return Item3; }
       }
+
+      [Obsolete ("Use LastAccessUtc instead. (Version 1.21.8)", false)]
+      public DateTime LastAccess
+      {
+        get { return Item3; }
+      }
     }
 
     private static readonly ILog s_log = LogManager.GetLogger (typeof (WxeFunctionStateManager));

--- a/Remotion/Web/UnitTests/Core/ExecutionEngine/WxeFunctionStateManagerTest.cs
+++ b/Remotion/Web/UnitTests/Core/ExecutionEngine/WxeFunctionStateManagerTest.cs
@@ -59,7 +59,7 @@ namespace Remotion.Web.UnitTests.Core.ExecutionEngine
 
       var functionStateManager = new WxeFunctionStateManager (_session);
 
-      Assert.That (functionStateManager.GetLastAccess (functionStateMetaData.FunctionToken), Is.EqualTo (lastAccess));
+      Assert.That (functionStateManager.GetLastAccessUtc (functionStateMetaData.FunctionToken), Is.EqualTo (lastAccess));
     }
 
     [Test]
@@ -98,10 +98,10 @@ namespace Remotion.Web.UnitTests.Core.ExecutionEngine
     {
       WxeFunctionStateManager functionStateManager = new WxeFunctionStateManager (_session);
       functionStateManager.Add (_functionState);
-      DateTime lastAccess = functionStateManager.GetLastAccess (_functionState.FunctionToken);
+      DateTime lastAccess = functionStateManager.GetLastAccessUtc (_functionState.FunctionToken);
       Thread.Sleep (1000);
       functionStateManager.Touch (_functionState.FunctionToken);
-      Assert.Greater (functionStateManager.GetLastAccess (_functionState.FunctionToken), lastAccess);
+      Assert.Greater (functionStateManager.GetLastAccessUtc (_functionState.FunctionToken), lastAccess);
     }
 
     [Test]

--- a/Remotion/Web/UnitTests/Core/ExecutionEngine/WxeFunctionStateManagerTest.cs
+++ b/Remotion/Web/UnitTests/Core/ExecutionEngine/WxeFunctionStateManagerTest.cs
@@ -51,7 +51,7 @@ namespace Remotion.Web.UnitTests.Core.ExecutionEngine
     [Test]
     public void InitializeFromExistingSession ()
     {
-      DateTime lastAccess = DateTime.Now;
+      DateTime lastAccess = DateTime.UtcNow;
       var functionStateMetaData = new WxeFunctionStateManager.WxeFunctionStateMetaData (Guid.NewGuid().ToString(), 1, lastAccess);
       var functionStates = new Dictionary<string, WxeFunctionStateManager.WxeFunctionStateMetaData>();
       functionStates.Add (functionStateMetaData.FunctionToken, functionStateMetaData);

--- a/Remotion/Web/UnitTests/Core/ExecutionEngine/WxeHandlerTest.cs
+++ b/Remotion/Web/UnitTests/Core/ExecutionEngine/WxeHandlerTest.cs
@@ -239,7 +239,7 @@ namespace Remotion.Web.UnitTests.Core.ExecutionEngine
     [Test]
     public void RetrieveExistingFunctionState ()
     {
-      DateTime timeBeforeRefresh = DateTime.Now;
+      DateTime timeBeforeRefresh = DateTime.UtcNow;
       Thread.Sleep (20);
 
       WxeFunctionState functionState = _wxeHandler.ResumeExistingFunctionState (CurrentHttpContext, c_functionTokenForFunctionStateWithEnabledCleanUp);
@@ -392,7 +392,7 @@ namespace Remotion.Web.UnitTests.Core.ExecutionEngine
       queryString.Set (WxeHandler.Parameters.WxeAction, WxeHandler.Actions.Refresh);
       HttpContextHelper.SetQueryString (CurrentHttpContext, queryString);
 
-      DateTime timeBeforeRefresh = DateTime.Now;
+      DateTime timeBeforeRefresh = DateTime.UtcNow;
       Thread.Sleep (20);
 
       WxeFunctionState functionState = _wxeHandler.ResumeExistingFunctionState (CurrentHttpContext, c_functionTokenForFunctionStateWithEnabledCleanUp);
@@ -412,7 +412,7 @@ namespace Remotion.Web.UnitTests.Core.ExecutionEngine
       queryString.Set (WxeHandler.Parameters.WxeAction, WxeHandler.Actions.Refresh);
       HttpContextHelper.SetQueryString (CurrentHttpContext, queryString);
 
-      DateTime timeBeforeRefresh = DateTime.Now;
+      DateTime timeBeforeRefresh = DateTime.UtcNow;
       Thread.Sleep (20);
 
       WxeFunctionState functionState =

--- a/Remotion/Web/UnitTests/Core/ExecutionEngine/WxeHandlerTest.cs
+++ b/Remotion/Web/UnitTests/Core/ExecutionEngine/WxeHandlerTest.cs
@@ -245,7 +245,7 @@ namespace Remotion.Web.UnitTests.Core.ExecutionEngine
       WxeFunctionState functionState = _wxeHandler.ResumeExistingFunctionState (CurrentHttpContext, c_functionTokenForFunctionStateWithEnabledCleanUp);
 
       Assert.That (functionState, Is.SameAs (_functionStateWithEnabledCleanUp));
-      Assert.That (WxeFunctionStateManager.Current.GetLastAccess (c_functionTokenForFunctionStateWithEnabledCleanUp) > timeBeforeRefresh, Is.True);
+      Assert.That (WxeFunctionStateManager.Current.GetLastAccessUtc (c_functionTokenForFunctionStateWithEnabledCleanUp) > timeBeforeRefresh, Is.True);
       Assert.That (functionState.IsAborted, Is.False);
       Assert.That (WxeFunctionStateManager.Current.IsExpired (c_functionTokenForFunctionStateWithEnabledCleanUp), Is.False);
 
@@ -398,7 +398,7 @@ namespace Remotion.Web.UnitTests.Core.ExecutionEngine
       WxeFunctionState functionState = _wxeHandler.ResumeExistingFunctionState (CurrentHttpContext, c_functionTokenForFunctionStateWithEnabledCleanUp);
 
       Assert.That (functionState, Is.Null);
-      Assert.That (WxeFunctionStateManager.Current.GetLastAccess (c_functionTokenForFunctionStateWithEnabledCleanUp) > timeBeforeRefresh, Is.True);
+      Assert.That (WxeFunctionStateManager.Current.GetLastAccessUtc (c_functionTokenForFunctionStateWithEnabledCleanUp) > timeBeforeRefresh, Is.True);
       Assert.That (_functionStateWithEnabledCleanUp.IsAborted, Is.False);
       Assert.That (WxeFunctionStateManager.Current.IsExpired (c_functionTokenForFunctionStateWithEnabledCleanUp), Is.False);
 
@@ -419,7 +419,7 @@ namespace Remotion.Web.UnitTests.Core.ExecutionEngine
           _wxeHandler.ResumeExistingFunctionState (CurrentHttpContext, c_functionTokenForFunctionStateWithMissingFunction);
 
       Assert.That (functionState, Is.Null);
-      Assert.That (WxeFunctionStateManager.Current.GetLastAccess (c_functionTokenForFunctionStateWithMissingFunction) > timeBeforeRefresh, Is.True);
+      Assert.That (WxeFunctionStateManager.Current.GetLastAccessUtc (c_functionTokenForFunctionStateWithMissingFunction) > timeBeforeRefresh, Is.True);
       Assert.That (_functionStateWithMissingFunction.IsAborted, Is.False);
       Assert.That (WxeFunctionStateManager.Current.IsExpired (c_functionTokenForFunctionStateWithMissingFunction), Is.False);
 


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-3427