### PR TITLE
RM-7468: ProcessUtils.GracefulProcessShutdown does not handle Win32Exception when killing a terminating process

### DIFF
--- a/Remotion/Web/Development.WebTesting/Utilities/ProcessUtils.cs
+++ b/Remotion/Web/Development.WebTesting/Utilities/ProcessUtils.cs
@@ -138,6 +138,7 @@ namespace Remotion.Web.Development.WebTesting.Utilities
       // Try to gracefully close the process
       if (process.CloseMainWindow())
       {
+        // No exception is thrown when calling .WaitForExit(..) on an already exited process.
         if (process.WaitForExit (timeoutInMilliseconds))
           return;
       }
@@ -153,7 +154,16 @@ namespace Remotion.Web.Development.WebTesting.Utilities
         // https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.kill#remarks
         // This exception can be swallowed safely, as the process that should be killed is already terminating.
       }
+      catch (InvalidOperationException)
+      {
+        // Thrown if the process has already exited, or no process is associated with the Process object.
+        // https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.kill#System_Diagnostics_Process_Kill
+        // This exception can be swallowed safely, as we are sure that a process is associated and the process has
+        // already exited, therefore the method can return at this point.
+        return;
+      }
 
+      // No exception is thrown when calling .WaitForExit(..) on an already exited process.
       if (process.WaitForExit (timeoutInMilliseconds))
         return;
 

--- a/Remotion/Web/Development.WebTesting/Utilities/ProcessUtils.cs
+++ b/Remotion/Web/Development.WebTesting/Utilities/ProcessUtils.cs
@@ -143,7 +143,14 @@ namespace Remotion.Web.Development.WebTesting.Utilities
       }
 
       // Force closing the process
-      process.Kill();
+      try
+      {
+        process.Kill();
+      }
+      catch (Win32Exception)
+      {
+        // Thrown if the .Kill() method is called while the process is currently terminating.
+      }
 
       if (process.WaitForExit (timeoutInMilliseconds))
         return;

--- a/Remotion/Web/Development.WebTesting/Utilities/ProcessUtils.cs
+++ b/Remotion/Web/Development.WebTesting/Utilities/ProcessUtils.cs
@@ -150,6 +150,8 @@ namespace Remotion.Web.Development.WebTesting.Utilities
       catch (Win32Exception)
       {
         // Thrown if the .Kill() method is called while the process is currently terminating.
+        // https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.kill#remarks
+        // This exception can be swallowed safely, as the process that should be killed is already terminating.
       }
 
       if (process.WaitForExit (timeoutInMilliseconds))


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-7468