### PR TITLE
RM-6490: Fix AutoCompleteReferenceValue postback queuing

### DIFF
--- a/Remotion/ObjectBinding/Web/Res/HTML/BocAutoCompleteReferenceValue.jquery.js
+++ b/Remotion/ObjectBinding/Web/Res/HTML/BocAutoCompleteReferenceValue.jquery.js
@@ -360,10 +360,8 @@
                 } else {
                     clearTimeout(timeout);
                     var lastKeyPressCode = state.lastKeyPressCode;
-                    timeout = setTimeout(function () {
-                        invalidateResult();
-                        acceptInput(lastKeyPressCode);
-                    }, 200);
+                    invalidateResult();
+                    acceptInput(lastKeyPressCode);
                 }
             }
         }).click(function() {


### PR DESCRIPTION
https://re-motion.atlassian.net/browse/RM-6490

Tested the scenarios described in the issue:
1. When the value is cleared from the Textbox with IE's "reset" control ("x"), and the button is clicked, the Textbox's AutoPostBack is executed, then the button's postback is executed.
2. When the value is cleared from the Textbox manually, and the button is clicked, the Textbox's AutoPostBack is executed, then the button's postback is executed.
3. When the value is cleared in the currently focused BocAutoCompleteReferenceValue by selecting the text using the mouse and then pressing Backspace or Delete before clicking the button, the TextBox is posted as an empty value and the hidden field holds the value `==null==`.